### PR TITLE
[#377] Ligretto. Remove Horizontal scroll on Main Page

### DIFF
--- a/apps/ligretto-frontend/src/components/layouts/base/BaseLayout.tsx
+++ b/apps/ligretto-frontend/src/components/layouts/base/BaseLayout.tsx
@@ -3,5 +3,5 @@ import type { BoxProps } from '@memebattle/ui'
 import { Box } from '@memebattle/ui'
 
 export const BaseLayout = (props: BoxProps) => (
-  <Box component="main" display="flex" flex={1} flexDirection="column" width="100%" height="100vh" minHeight="100vh" {...props} />
+  <Box component="main" display="flex" flex={1} flexDirection="column" width="100%" height="100vh" {...props} />
 )

--- a/apps/ligretto-frontend/src/components/layouts/base/BaseLayout.tsx
+++ b/apps/ligretto-frontend/src/components/layouts/base/BaseLayout.tsx
@@ -3,5 +3,5 @@ import type { BoxProps } from '@memebattle/ui'
 import { Box } from '@memebattle/ui'
 
 export const BaseLayout = (props: BoxProps) => (
-  <Box component="main" display="flex" flex={1} flexDirection="column" width="100vw" height="100vh" minHeight="100vh" {...props} />
+  <Box component="main" display="flex" flex={1} flexDirection="column" width="100%" height="100vh" minHeight="100vh" {...props} />
 )


### PR DESCRIPTION
100vw changed to 100% in file:
_apps/ligretto-frontend/src/components/layouts/base/BaseLayout.tsx_

The result is tested in google chrome. There is no horizontal scroll. Other functionality is not broken.