### PR TITLE
[#404] Ligretto: fix username styles

### DIFF
--- a/apps/ligretto-frontend/src/components/blocks/home/UserInfo/UserInfo.tsx
+++ b/apps/ligretto-frontend/src/components/blocks/home/UserInfo/UserInfo.tsx
@@ -49,7 +49,7 @@ export const UserInfo: React.FC<UserInfoProps> = ({ onClick, username, onButtonC
           <Typography
             fontSize="1.5rem"
             textOverflow="ellipsis"
-            max-width="80%"
+            maxWidth="80%"
             whiteSpace="nowrap"
             overflow="hidden"
             marginLeft={username ? '1.375rem' : '0'}

--- a/apps/ligretto-frontend/src/components/blocks/home/UserInfo/UserInfo.tsx
+++ b/apps/ligretto-frontend/src/components/blocks/home/UserInfo/UserInfo.tsx
@@ -46,7 +46,15 @@ export const UserInfo: React.FC<UserInfoProps> = ({ onClick, username, onButtonC
           </StyledLogoutButton>
         ) : null}
         <StyledAuthorizedButton color="primary" variant="contained" size="large" endIcon={username ? <CreateIcon /> : null} onClick={onButtonClick}>
-          <Typography fontSize="1.5rem" textOverflow="ellipsis" width="10rem" overflow="hidden" marginLeft={username ? '1.375rem' : '0'}>
+          <Typography
+            fontSize="1.5rem"
+            textOverflow="ellipsis"
+            max-width="80%"
+            whiteSpace="nowrap"
+            overflow="hidden"
+            marginLeft={username ? '1.375rem' : '0'}
+            padding="0rem 0.5rem"
+          >
             {username || 'Sign in'}
           </Typography>
         </StyledAuthorizedButton>


### PR DESCRIPTION
Я не смогла найти в figma дизайн кнопки, когда юзер залогинен, поэтому немного поправила:

- изменила `width: 10rem` на `max-width: 80%`, т.к. при коротком `username`, карандаш зависает в воздухе.

было:

![image](https://github.com/MemeBattle/monorepo/assets/67325499/523f1155-1f7a-493f-9f53-f163b9ea7b5a)


![image](https://github.com/MemeBattle/monorepo/assets/67325499/f9e2a32e-845d-4ae4-85a5-6c4a7a29a3f3)

стало:

![image](https://github.com/MemeBattle/monorepo/assets/67325499/04154804-bbdb-403f-8408-65e1506a86b3)

![image](https://github.com/MemeBattle/monorepo/assets/67325499/bdb0f9e0-849e-4c9f-bf8f-12d374ce9fb8)


- добавила `padding-right: 0.5rem`, чтобы карандаш не прилипал к имени, и `padding-left: 0.5rem`, чтобы отцентрировать `username`.