### PR TITLE
[HOTFIX] Add some styles to Details and Summary components

### DIFF
--- a/apps/blog/src/components/Details/Details.tsx
+++ b/apps/blog/src/components/Details/Details.tsx
@@ -1,3 +1,3 @@
 export function Details({ children }: React.PropsWithChildren) {
-  return <details className="rounded-lg shadow cursor-pointer hover:shadow-lg not-prose group">{children}</details>
+  return <details className="rounded-lg shadow cursor-pointer overflow-hidden hover:shadow-lg not-prose group">{children}</details>
 }

--- a/apps/blog/src/components/Summary/Summary.tsx
+++ b/apps/blog/src/components/Summary/Summary.tsx
@@ -1,6 +1,6 @@
 export function Summary({ children }: React.PropsWithChildren) {
   return (
-    <summary className="p-6 text-xl flex items-center gap-6 list-none font-semibold">
+    <summary className="sm:p-6 p-2 flex lg:text-xl text-base [&::-webkit-details-marker]:hidden items-center gap-6 list-none font-semibold">
       <svg width="10" height="17" viewBox="0 0 10 17" fill="none" className="group-open:rotate-90" xmlns="http://www.w3.org/2000/svg">
         <path d="M1.25 1.25L8.75 8.75L1.25 16.25" stroke="#676E76" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
       </svg>


### PR DESCRIPTION
<img width="819" alt="image" src="https://github.com/MemeBattle/monorepo/assets/59825083/b68ec37f-8311-45eb-8cab-3ec449e899cd">

Дабавил "overflow: hidden" в Details
теперь картинка не вылезает за пределы компонента

Для Safary пришлось добавить несколько костыльный стиль "[&::-webkit-details-marker]:hidden", что б убрать дефолтный маркер

Добавил чуть адаптива:
- теперь размер заголовка раскрывашки меняется вместе с размером шрифта основного текста блога  
- уменьшил падинги для мобилки
