### PR TITLE
Sets up CI for the CAS

### DIFF
--- a/.github/workflows/cas-pr.yml
+++ b/.github/workflows/cas-pr.yml
@@ -1,0 +1,57 @@
+name: 'CAS pull request'
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'apps/cas/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/cas-**'
+
+jobs:
+  fmt:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Cargo fmt
+        working-directory: apps/cas
+        run: cargo fmt --check
+
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo test
+        working-directory: apps/cas
+        run: cargo test
+
+  clippy:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cargo clippy
+        working-directory: apps/cas
+        run: cargo clippy --all-targets --all-features


### PR DESCRIPTION
Add a GitHub Actions workflow to run Rust checks for the CAS application on pull requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-17d22fd8-5204-4a09-9499-0bbdeecb5c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17d22fd8-5204-4a09-9499-0bbdeecb5c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up CI for the CAS app on PRs affecting `apps/cas/**`, `Cargo.*`, or `cas-*` workflows.
> 
> - Adds `.github/workflows/cas-pr.yml` with three jobs: `fmt` (rustfmt check), `test` (cargo test), and `clippy` (lint)
> - Uses `dtolnay/rust-toolchain@stable` and runs in `apps/cas` directory
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0ae2c23e6cff20488cfb5dabef9f3ee8a72536a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

closes #558 