### PR TITLE
refactor(ligretto): ref-as-prop и isHighlighted для карточных компонентов

### DIFF
--- a/apps/ligretto-frontend/src/entities/card/ui/Card/Card.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/Card/Card.tsx
@@ -18,6 +18,8 @@ interface CardProps {
   isDisabled?: boolean
   /** Darkened state of card (E.x. when other card selected) **/
   isDarkened?: boolean
+  /** Highlighted state of card **/
+  isHighlighted?: boolean
   /** Callback on click outside **/
   onClick?: () => void
   /** Callback on click **/
@@ -88,7 +90,7 @@ const colorByCardColors: Record<CardColors, string> = {
   [CardColors.empty]: 'transparent',
 }
 
-const StyledCardNotForwardedPropsSet = new Set<PropertyKey>(['isDarkened', 'isDisabled', 'isSelected', 'size'])
+const StyledCardNotForwardedPropsSet = new Set<PropertyKey>(['isDarkened', 'isDisabled', 'isHighlighted', 'isSelected', 'size'])
 
 const StyledCard = styled(ButtonBase, { shouldForwardProp: prop => !StyledCardNotForwardedPropsSet.has(prop) })<{
   color: CardColors
@@ -96,8 +98,9 @@ const StyledCard = styled(ButtonBase, { shouldForwardProp: prop => !StyledCardNo
   isDisabled?: boolean
   isSelected?: boolean
   isDarkened?: boolean
+  isHighlighted?: boolean
   size: CardSize
-}>(({ color, isDisabled, isSelected, isDarkened, size, theme }) => ({
+}>(({ color, isDisabled, isSelected, isDarkened, isHighlighted, size, theme }) => ({
   height: heightByCardSize[size],
   width: widthByCardSize[size],
   opacity: color === CardColors.empty ? 0 : 1,
@@ -112,9 +115,9 @@ const StyledCard = styled(ButtonBase, { shouldForwardProp: prop => !StyledCardNo
   cursor: isDisabled ? 'default' : 'pointer',
   transition: 'box-shadow 100ms',
   ':hover': {
-    boxShadow: isDisabled ? undefined : `0.1rem 0.1rem 0.8rem ${isSelected ? 'rgba(255,255,255,0.7)' : 'rgba(0, 0, 0, 0.5)'} `,
+    boxShadow: isDisabled ? undefined : `0.1rem 0.1rem 0.8rem ${isSelected || isHighlighted ? 'rgba(255,255,255,0.7)' : 'rgba(0, 0, 0, 0.5)'} `,
   },
-  boxShadow: isSelected ? '0.1rem 0.1rem 0.8rem rgba(255,255,255,0.7)' : undefined,
+  boxShadow: isSelected || isHighlighted ? '0.1rem 0.1rem 0.8rem rgba(255,255,255,0.7)' : undefined,
   [theme.breakpoints.down('lg')]: {
     height: tabletHeightBySize[size],
     width: tabletWidthBySize[size],
@@ -133,6 +136,7 @@ export const Card: React.FC<CardProps> = ({
   isDisabled = false,
   isSelected,
   isDarkened,
+  isHighlighted,
   onClick,
   onClickOutside,
   color = CardColors.empty,
@@ -145,6 +149,7 @@ export const Card: React.FC<CardProps> = ({
   return (
     <StyledCard
       isDarkened={isDarkened}
+      isHighlighted={isHighlighted}
       disableRipple={isDisabled}
       size={size}
       onMouseDown={onClick}

--- a/apps/ligretto-frontend/src/entities/card/ui/CardPlace/CardPlace.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardPlace/CardPlace.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { type PropsWithChildren, type Ref } from 'react'
 import { styled } from '@mui/material/styles'
 
 import { widthByCardSize, heightByCardSize, mobileHeightBySize, mobileWidthBySize, tabletWidthBySize, tabletHeightBySize } from '../Card'
@@ -7,6 +7,7 @@ export type CardPlaceSize = 'small' | 'medium' | 'large'
 
 export interface CardPlaceProps {
   size?: CardPlaceSize
+  ref?: Ref<HTMLDivElement>
 }
 
 export const borderBySize: Record<CardPlaceSize, string> = {
@@ -49,10 +50,8 @@ const StyledCard = styled('div')<{ size: CardPlaceSize }>(({ size, theme }) => (
   },
 }))
 
-export const CardPlace: React.FC<React.PropsWithChildren<CardPlaceProps>> = ({ children, size = 'medium' }) => (
-  <StyledCardPlace size={size}>
+export const CardPlace = ({ children, size = 'medium', ref }: PropsWithChildren<CardPlaceProps>) => (
+  <StyledCardPlace ref={ref} size={size}>
     <StyledCard size={size}>{children}</StyledCard>
   </StyledCardPlace>
 )
-
-CardPlace.displayName = 'CardPlace'

--- a/apps/ligretto-frontend/src/entities/card/ui/CardsRow/CardsRow.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardsRow/CardsRow.tsx
@@ -1,15 +1,13 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, Ref } from 'react'
 import { Stack, useMediaQuery, useTheme } from '@memebattle/ui'
 
-export const CardsRow = ({ children }: { children: ReactNode }) => {
+export const CardsRow = ({ children, ref }: { children: ReactNode; ref?: Ref<HTMLDivElement> }) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <Stack direction="row" sx={{ alignItems: 'flex-start' }} spacing={isMobile ? '2px' : 0.75}>
+    <Stack ref={ref} direction="row" sx={{ alignItems: 'flex-start' }} spacing={isMobile ? '2px' : 0.75}>
       {children}
     </Stack>
   )
 }
-
-CardsRow.displayName = 'CardsRow'

--- a/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { type Ref } from 'react'
 import type { Card as PlayerCard } from '@memebattle/ligretto-shared'
 import { Hotkey } from '#ducks/game'
 import { CardsRow } from '../CardsRow'
@@ -12,12 +12,14 @@ export interface CardsStackProps {
   onStackOpenDeckCardClick: () => void
   onStackDeckCardClick: () => void
   onStackDeckCardOutsideClick: () => void
-  isDndEnabled: boolean
+  isDndEnabled?: boolean
   isStackOpenDeckSelected: boolean
   isStackOpenDeckDarkened: boolean
+  isStackDeckHighlighted?: boolean
+  ref?: Ref<HTMLDivElement>
 }
 
-export const CardsStack: React.FC<CardsStackProps> = ({
+export const CardsStack = ({
   stackOpenDeckCard,
   stackDeckCards,
   onStackOpenDeckCardClick,
@@ -26,8 +28,10 @@ export const CardsStack: React.FC<CardsStackProps> = ({
   isDndEnabled,
   isStackOpenDeckSelected,
   isStackOpenDeckDarkened,
-}) => (
-  <CardsRow>
+  isStackDeckHighlighted,
+  ref,
+}: CardsStackProps) => (
+  <CardsRow ref={ref}>
     <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.x : undefined}>
       <CardPlace>
         {stackOpenDeckCard && (
@@ -44,7 +48,7 @@ export const CardsStack: React.FC<CardsStackProps> = ({
 
     <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.space : undefined}>
       <CardPlace>
-        <Card color={stackDeckCards[0]?.color} onClick={onStackDeckCardClick} />
+        <Card color={stackDeckCards[0]?.color} onClick={onStackDeckCardClick} isHighlighted={isStackDeckHighlighted} />
       </CardPlace>
     </CardHotkeyBadge>
   </CardsRow>

--- a/apps/ligretto-frontend/src/features/player/ui/CardsPanel/CardsPanel.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/CardsPanel/CardsPanel.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react'
-import { PlayerStatus } from '@memebattle/ligretto-shared'
+import type { FC, PropsWithChildren } from 'react'
+import type { PlayerStatus } from '@memebattle/ligretto-shared'
 
 import { PlayerCardsStack } from '#features/player/ui/PlayerCardsStack'
 import { LigrettoDeckContainer } from '../LigrettoDeckContainer'
@@ -31,7 +31,7 @@ const CardsPanelMobile = () => (
   </Stack>
 )
 
-export const CardsPanel: FC<CardsPanelProps> = ({ player }) => {
+export const CardsPanel: FC<PropsWithChildren<CardsPanelProps>> = ({ player, children }) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
@@ -42,9 +42,7 @@ export const CardsPanel: FC<CardsPanelProps> = ({ player }) => {
   return (
     <Box sx={{ mb: 1.5 }} display="flex" justifyContent="center">
       <Stack spacing={2} direction="row">
-        {player?.status === PlayerStatus.InGame
-          ? [<PlayerCardsStack key="stack" />, <PlayerRowCardsContainer key="row" />, <LigrettoDeckContainer key="deck" />]
-          : null}
+        {children}
         {player ? <Player status={player.status} username={player.username} avatar={player?.avatar} isActivePlayer /> : null}
       </Stack>
     </Box>

--- a/apps/ligretto-frontend/src/features/player/ui/CardsPanelContainer/CardsPanelContainer.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/CardsPanelContainer/CardsPanelContainer.tsx
@@ -9,6 +9,10 @@ import { getRandomAvatar } from '#shared/ui/Avatar/getRandomAvatar'
 import { CardsPanel } from '../CardsPanel'
 
 import { usePanelHotkeys } from './usePanelHotkeys'
+import { PlayerStatus } from '@memebattle/ligretto-shared'
+import { LigrettoDeckContainer } from '../LigrettoDeckContainer'
+import { PlayerCardsStack } from '../PlayerCardsStack'
+import { PlayerRowCardsContainer } from '../PlayerRowCardsContainer'
 
 const cardsPanelContainerSelector = createSelector(
   [activePlayerSelector, playerLigrettoDeckCardsSelector, isDndEnabledSelector],
@@ -31,5 +35,11 @@ export const CardsPanelContainer = () => {
     }
   }, [player])
 
-  return <CardsPanel player={playerWithStaticAvatar} />
+  return (
+    <CardsPanel player={playerWithStaticAvatar}>
+      {player?.status === PlayerStatus.InGame
+        ? [<PlayerCardsStack key="stack" />, <PlayerRowCardsContainer key="row" />, <LigrettoDeckContainer key="deck" />]
+        : null}
+    </CardsPanel>
+  )
 }

--- a/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { type Ref } from 'react'
 import { Typography } from '@memebattle/ui'
 import type { Card as PlayerCards } from '@memebattle/ligretto-shared'
 
@@ -7,19 +7,30 @@ import { CardPlace, Card, CardHotkeyBadge } from '#entities/card'
 
 import styles from './LigrettoPack.module.scss'
 
-interface LigrettoPack {
+interface LigrettoPackProps {
   count: number
   isDndEnabled: boolean
   ligrettoDeckCards: PlayerCards[]
   onLigrettoDeckCardClick: () => void
+  isHighlighted?: boolean
+  isDisabled?: boolean
+  ref?: Ref<HTMLDivElement>
 }
 
-export const LigrettoPack: React.FC<LigrettoPack> = ({ count, isDndEnabled, ligrettoDeckCards, onLigrettoDeckCardClick }) => (
-  <div className={styles.ligrettoPack}>
+export const LigrettoPack = ({
+  count,
+  isDndEnabled,
+  ligrettoDeckCards,
+  onLigrettoDeckCardClick,
+  isHighlighted,
+  isDisabled,
+  ref,
+}: LigrettoPackProps) => (
+  <div ref={ref} className={styles.ligrettoPack}>
     <div className={styles.cardWrapper}>
       <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.l : undefined}>
         <CardPlace>
-          <Card color={ligrettoDeckCards[0]?.color} onClick={onLigrettoDeckCardClick} />
+          <Card color={ligrettoDeckCards[0]?.color} onClick={onLigrettoDeckCardClick} isHighlighted={isHighlighted} isDisabled={isDisabled} />
         </CardPlace>
       </CardHotkeyBadge>
     </div>

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react'
+import { useMemo, type Ref } from 'react'
 import { Box, Stack } from '@memebattle/ui'
 import type { Card as OpponentCard, UUID } from '@memebattle/ligretto-shared'
 import { PlayerStatus } from '@memebattle/ligretto-shared'
@@ -16,9 +16,10 @@ export interface OpponentCardsProps {
   avatar?: string
   status: PlayerStatus
   id: UUID
+  ref?: Ref<HTMLDivElement>
 }
 
-export const Opponent = forwardRef<unknown, OpponentCardsProps>(({ stackOpenDeckCards, cards, avatar, username, status, id }, ref) => {
+export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, ref }: OpponentCardsProps) => {
   const stackOpenDeckCard = useMemo(() => (stackOpenDeckCards.length ? stackOpenDeckCards.slice(-1)[0] : {}), [stackOpenDeckCards])
   const avatarImg = useMemo(() => (avatar ? buildCasStaticUrl(avatar) : getRandomAvatar(id)), [avatar, id])
 
@@ -39,6 +40,4 @@ export const Opponent = forwardRef<unknown, OpponentCardsProps>(({ stackOpenDeck
       ) : null}
     </Box>
   )
-})
-
-Opponent.displayName = 'Opponent'
+}

--- a/apps/ligretto-frontend/src/features/playground/ui/Playground.tsx
+++ b/apps/ligretto-frontend/src/features/playground/ui/Playground.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import { useMemo, type Ref, type RefObject } from 'react'
 import type { CardsDeck, Card } from '@memebattle/ligretto-shared'
 import last from 'lodash/last'
 import { CardPlace, Card as CardComponent } from '#entities/card'
@@ -7,11 +7,13 @@ import { TableCards } from './TableCards'
 export interface PlaygroundProps {
   cardsDecks: Array<CardsDeck | null>
   onDeckClick: (playgroundDeckIndex: number) => void
+  ref?: Ref<HTMLDivElement>
+  deckRefs?: Array<RefObject<HTMLDivElement | null> | undefined>
 }
 
 const getLastCard = (deck: CardsDeck | null): Card | undefined => last(deck?.cards)
 
-export const Playground: React.FC<PlaygroundProps> = ({ cardsDecks, onDeckClick }) => {
+export const Playground = ({ cardsDecks, onDeckClick, ref, deckRefs }: PlaygroundProps) => {
   const cards: (Card | undefined)[] = useMemo(() => {
     const newPlayerCardsArr = []
     for (let i = 0; i < 12; i++) {
@@ -21,14 +23,12 @@ export const Playground: React.FC<PlaygroundProps> = ({ cardsDecks, onDeckClick 
   }, [cardsDecks])
 
   return (
-    <TableCards>
+    <TableCards ref={ref}>
       {cards.map((card, index) => (
-        <CardPlace key={index} size="large">
+        <CardPlace key={index} size="large" ref={deckRefs?.[index]}>
           {card && <CardComponent size="large" {...card} onClick={() => onDeckClick(index)} />}
         </CardPlace>
       ))}
     </TableCards>
   )
 }
-
-Playground.displayName = 'Playground'

--- a/apps/ligretto-frontend/src/features/playground/ui/TableCards/TableCards.tsx
+++ b/apps/ligretto-frontend/src/features/playground/ui/TableCards/TableCards.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react'
+import { Children, type PropsWithChildren, type Ref } from 'react'
 import { Box } from '@memebattle/ui'
 
 import { styled } from '@mui/material/styles'
@@ -19,8 +19,8 @@ const StyledGrid = styled('div')(({ theme }) => ({
   },
 }))
 
-export const TableCards: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <Box display="flex" justifyContent="center" alignItems="center" flex={1}>
+export const TableCards = ({ children, ref }: PropsWithChildren<{ ref?: Ref<HTMLDivElement> }>) => (
+  <Box ref={ref} display="flex" justifyContent="center" alignItems="center" flex={1}>
     <StyledGrid>
       {Children.map(children, (child, index) => (
         <Box key={index}>{child}</Box>
@@ -28,5 +28,3 @@ export const TableCards: React.FC<React.PropsWithChildren> = ({ children }) => (
     </StyledGrid>
   </Box>
 )
-
-TableCards.displayName = 'TableCards'


### PR DESCRIPTION
Подготовительный рефакторинг переиспользуемых карточных компонентов (выделено из ветки онбординга).

## Что внутри
- Миграция `forwardRef`/`React.FC` на ref-as-prop (React 19): `CardPlace`, `CardsRow`, `CardsStack`, `Opponent`, `Playground`, `TableCards`, `LigrettoPack`
- Проп `isHighlighted` у `Card` + проброс в `CardsStack` (`isStackDeckHighlighted`) и `LigrettoPack`
- `CardsPanel` принимает `children`; `CardsPanelContainer` подаёт их (с восстановленными `key` в массиве элементов)

Изменения независимы и не тянут код онбординга. `ts-check` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)