### PR TITLE
feat(ligretto): TouchHint component + story

### DIFF
--- a/apps/ligretto-frontend/src/pages/onboarding/TouchHint.stories.tsx
+++ b/apps/ligretto-frontend/src/pages/onboarding/TouchHint.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import type { CSSProperties } from 'react'
+import { TouchHint } from './TouchHint'
+
+const wrapStyle: CSSProperties = {
+  background: '#3d9970',
+  width: '100%',
+  height: 300,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+const targetStyle: CSSProperties = {
+  width: 120,
+  height: 80,
+  borderRadius: 8,
+  border: '2px solid white',
+  color: 'white',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 13,
+}
+
+const meta: Meta<typeof TouchHint> = {
+  title: 'Ligretto / TouchHint',
+  component: TouchHint,
+  decorators: [
+    Story => (
+      <div style={wrapStyle}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof TouchHint>
+
+/** The pulsing touch icon appears 3 seconds after mount. */
+export const DefaultView: Story = {
+  render: () => (
+    <TouchHint>
+      <div style={targetStyle}>Target</div>
+    </TouchHint>
+  ),
+}

--- a/apps/ligretto-frontend/src/pages/onboarding/TouchHint.tsx
+++ b/apps/ligretto-frontend/src/pages/onboarding/TouchHint.tsx
@@ -1,0 +1,69 @@
+import Popper from '@mui/material/Popper'
+import Fade from '@mui/material/Fade'
+
+import TouchAppIcon from '@mui/icons-material/TouchApp'
+import { useEffect, useRef, useState, type PropsWithChildren } from 'react'
+import { Box } from '@memebattle/ui'
+import { styled, keyframes } from '@mui/material/styles'
+
+const pulse = keyframes({
+  '0%': {
+    transform: 'scale(1)',
+  },
+  '50%': {
+    transform: 'scale(1.5)',
+  },
+  '100%': {
+    transform: 'scale(1)',
+  },
+})
+
+const AnimatedTouchAppIcon = styled(TouchAppIcon)({
+  animation: `${pulse} 2s ease-in-out infinite`,
+})
+
+export function TouchHint({ children }: PropsWithChildren) {
+  const anchorRef = useRef<HTMLDivElement | null>(null)
+
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setIsVisible(true)
+    }, 3000)
+
+    return () => clearTimeout(timerId)
+  }, [])
+
+  return (
+    <>
+      <Box ref={anchorRef}>{children}</Box>
+
+      <Popper
+        modifiers={[
+          {
+            name: 'flip',
+            enabled: false,
+            options: {
+              altBoundary: false,
+              rootBoundary: 'document',
+              padding: 8,
+            },
+          },
+        ]}
+        open={isVisible}
+        anchorEl={anchorRef.current}
+        disablePortal
+        transition
+      >
+        {({ TransitionProps }) => (
+          <Fade {...TransitionProps}>
+            <Box marginTop="-1.2rem">
+              <AnimatedTouchAppIcon fontSize="large" />
+            </Box>
+          </Fade>
+        )}
+      </Popper>
+    </>
+  )
+}


### PR DESCRIPTION
Extracts the reusable `TouchHint` component out of the onboarding flow into its own PR.

## What's inside
- `TouchHint` — a wrapper that renders a pulsing touch-app icon (MUI `Popper`) over its children after a short delay, used to hint a tappable target.
- Storybook story `TouchHint.stories.tsx`.

Independent change, no onboarding logic pulled in. `ts-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)