### PR TITLE
fix(ligretto): мобильная раскладка панели карт и локализация таблицы очков

### DIFF
--- a/apps/ligretto-frontend/src/features/player-scores-table/ui/PlayersScoresTable.tsx
+++ b/apps/ligretto-frontend/src/features/player-scores-table/ui/PlayersScoresTable.tsx
@@ -29,13 +29,13 @@ export const PlayersScoresTable: FC<PlayersScoresTableProps> = ({ players }) => 
         <Grid container spacing={4}>
           {!isMobile && <PlayersScoresTableCell size={columnsProps.avatar}></PlayersScoresTableCell>}
           <PlayersScoresTableCell size={columnsProps.name}>
-            <Typography variant="body2">Name</Typography>
+            <Typography variant="body2">Имя</Typography>
           </PlayersScoresTableCell>
           <PlayersScoresTableCell size={columnsProps.round} sx={{ justifyContent: 'flex-end' }}>
-            <Typography variant="body2">Round</Typography>
+            <Typography variant="body2">Раунд</Typography>
           </PlayersScoresTableCell>
           <PlayersScoresTableCell size={columnsProps.total} sx={{ justifyContent: 'flex-end' }}>
-            <Typography variant="body2">Total</Typography>
+            <Typography variant="body2">Всего</Typography>
           </PlayersScoresTableCell>
         </Grid>
       </PlayersScoresTableHead>

--- a/apps/ligretto-frontend/src/features/player/ui/CardsPanel/CardsPanel.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/CardsPanel/CardsPanel.tsx
@@ -23,15 +23,32 @@ export const CardsPanel: FC<CardsPanelProps> = ({ player, stack, rowCards, ligre
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
+  if (isMobile) {
+    // Two stacked rows: the face-up row on top, the hand decks below it.
+    // The player badge does not fit here and is dropped, as it always was on mobile.
+    return (
+      <Stack sx={{ mb: 2 }} spacing={1}>
+        <Box display="flex" justifyContent="center">
+          {rowCards}
+        </Box>
+
+        <Box display="flex" justifyContent="center">
+          <Stack spacing={1} direction="row">
+            {stack}
+            {ligretto}
+          </Stack>
+        </Box>
+      </Stack>
+    )
+  }
+
   return (
     <Box sx={{ mb: 1.5 }} display="flex" justifyContent="center">
-      {/* Same single row everywhere — only the player card is dropped on mobile, where it would
-          not fit next to the decks. */}
-      <Stack spacing={isMobile ? 1 : 2} direction="row">
+      <Stack spacing={2} direction="row">
         {stack}
         {rowCards}
         {ligretto}
-        {isMobile || !player ? null : <Player status={player.status} username={player.username} avatar={player?.avatar} isActivePlayer />}
+        {player ? <Player status={player.status} username={player.username} avatar={player?.avatar} isActivePlayer /> : null}
       </Stack>
     </Box>
   )

--- a/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
@@ -36,6 +36,6 @@ export const LigrettoPack = ({
         </CardPlace>
       </CardHotkeyBadge>
     </div>
-    <Typography sx={{ fontSize: { xs: '0.375rem', sm: '1rem' } }}>В колоде: {count}</Typography>
+    <Typography sx={{ fontSize: { xs: '0.625rem', sm: '1rem' } }}>В колоде: {count}</Typography>
   </div>
 )

--- a/apps/ligretto-frontend/src/pages/onboarding/OnboardingPage.tsx
+++ b/apps/ligretto-frontend/src/pages/onboarding/OnboardingPage.tsx
@@ -157,11 +157,20 @@ function OnboardingPageBody() {
       >
         <GameGrid
           centerElement={
-            <Layer id="playgroundCards">
-              <Playground ref={playgroundRef} cardsDecks={game.playground.decks} onDeckClick={() => null} deckRefs={playgroundDeckRefs} />
-            </Layer>
+            // Below the `md` breakpoint MobileGameGrid stacks zones in a column; the extra top
+            // margin and the auto margin pin the player's cards to the bottom of the screen, and
+            // the slack between them and the playground is where the hints go.
+            <Box sx={{ marginTop: { xs: '1.5rem', md: 0 } }}>
+              <Layer id="playgroundCards">
+                <Playground ref={playgroundRef} cardsDecks={game.playground.decks} onDeckClick={() => null} deckRefs={playgroundDeckRefs} />
+              </Layer>
+            </Box>
           }
-          bottomElement={<OnboardingCardPanel stackRef={stackRef} playerRowRef={playerRowRef} ligrettoRef={ligrettoRef} cardRefs={cardRefs} />}
+          bottomElement={
+            <Box sx={{ marginTop: { xs: 'auto', md: 0 } }}>
+              <OnboardingCardPanel stackRef={stackRef} playerRowRef={playerRowRef} ligrettoRef={ligrettoRef} cardRefs={cardRefs} />
+            </Box>
+          }
         >
           {opponents.slice(0, OPPONENT_COUNT).map((props, index) => (
             <Layer key={props.id} id="opponent">

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
@@ -66,10 +66,8 @@ export const MobileGameGrid: React.FC<React.PropsWithChildren<RoomGridProps>> = 
         {child}
       </MobileOpponentCardsWrapper>
     ))}
-    <Box marginTop="1.5rem">{centerElement}</Box>
-    {/* The player's own cards stay pinned to the bottom of the screen; the slack between them and
-        the playground is where the onboarding puts its hints. */}
-    <Box marginTop="auto">{bottomElement}</Box>
+    {centerElement}
+    {bottomElement}
   </Room>
 )
 


### PR DESCRIPTION
Первый PR стека поверх #611. Независим от остальных.

- **CardsPanel**: возвращён двухрядный мобильный вариант (ряд сверху, колоды снизу), который был удалён при переводе на slots-API — это чинило бы регрессию мобильной вёрстки **реальной игры**.
- **MobileGameGrid**: онбординг-специфичные отступы убраны из общего виджета; страница онбординга задаёт их своими обёртками.
- **PlayersScoresTable**: заголовки Имя/Раунд/Всего (весь UI на русском).
- **LigrettoPack**: счётчик «В колоде» на телефоне 0.625rem вместо нечитаемых 0.375rem.

Проверено: ts-check, unit, oxlint/oxfmt; онбординг-флоу пройден в браузере на десктопе и мобильном вьюпорте.

Стек: #611 ← **этот PR** ← модель ← описания ← рубашка ← e2e/доки

🤖 Generated with [Claude Code](https://claude.com/claude-code)