### PR TITLE
feat(ligretto): рубашка карт, иконка перелистывания и test-id в карточных компонентах

### DIFF
--- a/apps/ligretto-frontend/src/ducks/game/selectors.ts
+++ b/apps/ligretto-frontend/src/ducks/game/selectors.ts
@@ -38,7 +38,9 @@ export const playerSelector = (state: All) => playersSelector(state)[currentUser
 export const playerCardsSelector = (state: All) => playerSelector(state)?.cards
 export const playerStackOpenDeckCardsSelector = (state: All) => playerSelector(state)?.stackOpenDeck.cards
 export const playerStackDeckCardsSelector = (state: All) => playerSelector(state)?.stackDeck.cards
+export const playerStackDeckHiddenSelector = (state: All) => playerSelector(state)?.stackDeck.isHidden
 export const playerLigrettoDeckCardsSelector = (state: All) => playerSelector(state)?.ligrettoDeck.cards
+export const playerLigrettoDeckHiddenSelector = (state: All) => playerSelector(state)?.ligrettoDeck.isHidden
 export const playerStatusSelector = (state: All) => playerSelector(state)?.status
 
 /** Local Player State */

--- a/apps/ligretto-frontend/src/entities/card/ui/Card/Card.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/Card/Card.tsx
@@ -4,6 +4,7 @@ import { ButtonBase } from '@mui/material'
 import { Typography, useOnClickOutside } from '@memebattle/ui'
 import { styled } from '@mui/material/styles'
 import type { CardPlaceSize } from '../CardPlace'
+import { CardBackFace } from './CardBackFace'
 
 type CardSize = 'small' | 'medium' | 'large'
 
@@ -20,6 +21,8 @@ interface CardProps {
   isDarkened?: boolean
   /** Highlighted state of card **/
   isHighlighted?: boolean
+  /** The card lies face down — the uniform back is drawn instead of the face **/
+  isHidden?: boolean
   /** Callback on click outside **/
   onClick?: () => void
   /** Callback on click **/
@@ -90,7 +93,7 @@ const colorByCardColors: Record<CardColors, string> = {
   [CardColors.empty]: 'transparent',
 }
 
-const StyledCardNotForwardedPropsSet = new Set<PropertyKey>(['isDarkened', 'isDisabled', 'isHighlighted', 'isSelected', 'size'])
+const StyledCardNotForwardedPropsSet = new Set<PropertyKey>(['isDarkened', 'isDisabled', 'isHidden', 'isHighlighted', 'isSelected', 'size'])
 
 const StyledCard = styled(ButtonBase, { shouldForwardProp: prop => !StyledCardNotForwardedPropsSet.has(prop) })<{
   color: CardColors
@@ -98,17 +101,20 @@ const StyledCard = styled(ButtonBase, { shouldForwardProp: prop => !StyledCardNo
   isDisabled?: boolean
   isSelected?: boolean
   isDarkened?: boolean
+  isHidden?: boolean
   isHighlighted?: boolean
   size: CardSize
-}>(({ color, isDisabled, isSelected, isDarkened, isHighlighted, size, theme }) => ({
+}>(({ color, isDisabled, isSelected, isDarkened, isHidden, isHighlighted, size, theme }) => ({
   height: heightByCardSize[size],
   width: widthByCardSize[size],
-  opacity: color === CardColors.empty ? 0 : 1,
+  // A face-down card is visible regardless of its (unknown to the viewer) color.
+  opacity: color === CardColors.empty && !isHidden ? 0 : 1,
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
   userSelect: 'none',
-  background: color ? colorByCardColors[color] : colorByCardColors.empty,
+  // No face color behind the back artwork: its transparent rounded corners would let the color shine through.
+  background: isHidden ? 'none' : color ? colorByCardColors[color] : colorByCardColors.empty,
   color: '#fff',
   fontSize: fontSizeByCardSize[size],
   filter: isDarkened ? 'grayscale(50%) brightness(0.95)' : 'none',
@@ -136,6 +142,7 @@ export const Card: React.FC<CardProps> = ({
   isDisabled = false,
   isSelected,
   isDarkened,
+  isHidden,
   isHighlighted,
   onClick,
   onClickOutside,
@@ -155,12 +162,17 @@ export const Card: React.FC<CardProps> = ({
       onMouseDown={onClick}
       isDisabled={isDisabled}
       isSelected={isSelected}
+      isHidden={isHidden}
       color={color}
       ref={ref}
     >
-      <Typography fontSize="inherit" component="span">
-        {value}
-      </Typography>
+      {isHidden ? (
+        <CardBackFace />
+      ) : (
+        <Typography fontSize="inherit" component="span">
+          {value}
+        </Typography>
+      )}
     </StyledCard>
   )
 }

--- a/apps/ligretto-frontend/src/entities/card/ui/Card/CardBackFace.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/Card/CardBackFace.tsx
@@ -1,0 +1,99 @@
+import { useId } from 'react'
+
+/** One corner fan of cards; the four corners render it mirrored. */
+const CornerFan = () => (
+  <g>
+    <rect x="45" y="55" width="95" height="210" rx="16" fill="#2E79D7" transform="rotate(-2 92 160)" />
+    <rect x="92" y="38" width="110" height="220" rx="16" fill="#16A43A" transform="rotate(-19 147 148)" />
+    <rect x="145" y="26" width="110" height="200" rx="16" fill="#FFD31A" transform="rotate(-35 200 126)" />
+    <rect x="190" y="28" width="125" height="160" rx="16" fill="#EF3B30" transform="rotate(-53 252 108)" />
+  </g>
+)
+
+/**
+ * The uniform Ligretto card back, drawn for a face-down card. Fills its
+ * parent; the same artwork for every card, so it leaks nothing about the face.
+ */
+export const CardBackFace = () => {
+  const clipId = useId()
+
+  return (
+    <svg width="100%" height="100%" viewBox="0 0 700 980" preserveAspectRatio="none" style={{ display: 'block' }} xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <clipPath id={clipId}>
+          <rect x="20" y="20" width="660" height="940" rx="48" />
+        </clipPath>
+      </defs>
+
+      <rect x="20" y="20" width="660" height="940" rx="48" fill="#0A4D98" />
+      <rect x="38" y="38" width="624" height="904" rx="34" fill="#0E5FB8" />
+
+      <g clipPath={`url(#${clipId})`}>
+        {/* Subtle diagonal motion lines */}
+        <g stroke="#2B75C8" strokeWidth="13" strokeLinecap="round" opacity="0.55">
+          <line x1="250" y1="80" x2="370" y2="-40" />
+          <line x1="315" y1="135" x2="460" y2="-10" />
+          <line x1="380" y1="195" x2="525" y2="50" />
+          <line x1="445" y1="255" x2="595" y2="105" />
+          <line x1="90" y1="410" x2="245" y2="255" />
+          <line x1="130" y1="485" x2="300" y2="315" />
+          <line x1="400" y1="650" x2="555" y2="495" />
+          <line x1="455" y1="715" x2="620" y2="550" />
+          <line x1="145" y1="850" x2="305" y2="690" />
+          <line x1="215" y1="920" x2="365" y2="770" />
+        </g>
+
+        <CornerFan />
+        <g transform="translate(700,0) scale(-1,1)">
+          <CornerFan />
+        </g>
+        <g transform="translate(0,980) scale(1,-1)">
+          <CornerFan />
+        </g>
+        <g transform="translate(700,980) scale(-1,-1)">
+          <CornerFan />
+        </g>
+
+        {/* Central confetti / motion marks */}
+        <g fill="none" strokeLinecap="round">
+          <line x1="280" y1="355" x2="260" y2="325" stroke="#EF3B30" strokeWidth="13" />
+          <line x1="350" y1="350" x2="350" y2="315" stroke="#2E79D7" strokeWidth="13" />
+          <line x1="415" y1="355" x2="430" y2="325" stroke="#EF3B30" strokeWidth="13" />
+          <line x1="305" y1="410" x2="292" y2="388" stroke="#16A43A" strokeWidth="10" />
+          <line x1="395" y1="410" x2="408" y2="389" stroke="#FFD31A" strokeWidth="10" />
+
+          <circle cx="350" cy="440" r="18" stroke="#FFD31A" strokeWidth="9" />
+          <polygon points="295,505 315,470 335,505" stroke="#FFD31A" strokeWidth="8" strokeLinejoin="round" />
+          <rect x="385" y="475" width="32" height="32" rx="5" stroke="#FFFFFF" strokeWidth="8" transform="rotate(12 401 491)" />
+
+          <line x1="270" y1="570" x2="250" y2="600" stroke="#EF3B30" strokeWidth="13" />
+          <line x1="350" y1="565" x2="350" y2="605" stroke="#2E79D7" strokeWidth="13" />
+          <line x1="430" y1="570" x2="452" y2="592" stroke="#16A43A" strokeWidth="13" />
+          <line x1="305" y1="625" x2="315" y2="645" stroke="#16A43A" strokeWidth="9" />
+          <line x1="395" y1="625" x2="408" y2="646" stroke="#FFD31A" strokeWidth="9" />
+        </g>
+
+        {/* Small white corner symbols */}
+        <g fill="none" stroke="#FFFFFF" strokeWidth="7" strokeLinecap="round" strokeLinejoin="round" opacity="0.95">
+          <circle cx="90" cy="92" r="15" />
+          <rect x="170" y="105" width="24" height="24" rx="4" transform="rotate(10 182 117)" />
+          <polygon points="127,185 145,214 109,214" />
+
+          <circle cx="610" cy="92" r="15" />
+          <rect x="506" y="105" width="24" height="24" rx="4" transform="rotate(-10 518 117)" />
+          <polygon points="573,185 591,214 555,214" />
+
+          <circle cx="90" cy="888" r="15" />
+          <rect x="170" y="845" width="24" height="24" rx="4" transform="rotate(-10 182 857)" />
+          <polygon points="127,792 145,821 109,821" />
+
+          <circle cx="610" cy="888" r="15" />
+          <rect x="506" y="845" width="24" height="24" rx="4" transform="rotate(10 518 857)" />
+          <polygon points="573,792 591,821 555,821" />
+        </g>
+      </g>
+
+      <rect x="20" y="20" width="660" height="940" rx="48" fill="none" stroke="#083E7A" strokeWidth="12" />
+    </svg>
+  )
+}

--- a/apps/ligretto-frontend/src/entities/card/ui/CardPlace/CardPlace.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardPlace/CardPlace.tsx
@@ -8,6 +8,7 @@ export type CardPlaceSize = 'small' | 'medium' | 'large'
 export interface CardPlaceProps {
   size?: CardPlaceSize
   ref?: Ref<HTMLDivElement>
+  dataTestId?: string
 }
 
 export const borderBySize: Record<CardPlaceSize, string> = {
@@ -50,8 +51,8 @@ const StyledCard = styled('div')<{ size: CardPlaceSize }>(({ size, theme }) => (
   },
 }))
 
-export const CardPlace = ({ children, size = 'medium', ref }: PropsWithChildren<CardPlaceProps>) => (
-  <StyledCardPlace ref={ref} size={size}>
+export const CardPlace = ({ children, size = 'medium', ref, dataTestId }: PropsWithChildren<CardPlaceProps>) => (
+  <StyledCardPlace ref={ref} size={size} data-test-id={dataTestId}>
     <StyledCard size={size}>{children}</StyledCard>
   </StyledCardPlace>
 )

--- a/apps/ligretto-frontend/src/entities/card/ui/CardsRow/CardsRow.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardsRow/CardsRow.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode, Ref } from 'react'
 import { Stack, useMediaQuery, useTheme } from '@memebattle/ui'
 
-export const CardsRow = ({ children, ref }: { children: ReactNode; ref?: Ref<HTMLDivElement> }) => {
+export const CardsRow = ({ children, ref, dataTestId }: { children: ReactNode; ref?: Ref<HTMLDivElement>; dataTestId?: string }) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   return (
-    <Stack ref={ref} direction="row" sx={{ alignItems: 'flex-start' }} spacing={isMobile ? '2px' : 0.75}>
+    <Stack ref={ref} data-test-id={dataTestId} direction="row" sx={{ alignItems: 'flex-start' }} spacing={isMobile ? '2px' : 0.75}>
       {children}
     </Stack>
   )

--- a/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.stories.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { CardColors } from '@memebattle/ligretto-shared'
+import { Box } from '@memebattle/ui'
+
+import { CardsStack } from './CardsStack'
+
+const meta: Meta<typeof CardsStack> = {
+  title: 'Ligretto / CardsStack',
+  component: CardsStack,
+  args: {
+    stackDeckCards: [
+      { value: 9, color: CardColors.blue },
+      { value: 2, color: CardColors.blue },
+      { value: 6, color: CardColors.green },
+    ],
+    isStackDeckHidden: true,
+    isStackOpenDeckSelected: false,
+    isStackOpenDeckDarkened: false,
+    onStackDeckCardClick: () => {},
+    onStackOpenDeckCardClick: () => {},
+    onStackDeckCardOutsideClick: () => {},
+  },
+  decorators: [
+    Story => (
+      <Box sx={{ m: 2, display: 'inline-block', background: '#3d9970', p: 4 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+}
+export default meta
+
+type Story = StoryObj<typeof CardsStack>
+
+/** The face-down deck shows the uniform card back; the open place is still empty. */
+export const Default: Story = {}
+
+/** A flipped card lies on the open pile next to the face-down deck. */
+export const WithOpenCard: Story = {
+  args: {
+    stackOpenDeckCard: { value: 9, color: CardColors.blue },
+    stackDeckCards: [
+      { value: 2, color: CardColors.blue },
+      { value: 6, color: CardColors.green },
+    ],
+  },
+}
+
+/** The deck place is highlighted to draw the player's attention. */
+export const DeckHighlighted: Story = {
+  args: {
+    isStackDeckHighlighted: true,
+  },
+}
+
+/** The open card is selected (e.g. picked via hotkey). */
+export const OpenCardSelected: Story = {
+  args: {
+    stackOpenDeckCard: { value: 9, color: CardColors.blue },
+    stackDeckCards: [{ value: 6, color: CardColors.green }],
+    isStackOpenDeckSelected: true,
+  },
+}
+
+/** The face-down deck is exhausted: the reshuffle icon hints that a click turns the open pile over. */
+export const EmptyDeckReshuffle: Story = {
+  args: {
+    stackDeckCards: [],
+    stackOpenDeckCard: { value: 6, color: CardColors.green },
+  },
+}

--- a/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.tsx
+++ b/apps/ligretto-frontend/src/entities/card/ui/CardsStack/CardsStack.tsx
@@ -1,4 +1,6 @@
 import { type Ref } from 'react'
+import CachedIcon from '@mui/icons-material/Cached'
+import { styled } from '@mui/material/styles'
 import type { Card as PlayerCard } from '@memebattle/ligretto-shared'
 import { Hotkey } from '#ducks/game'
 import { CardsRow } from '../CardsRow'
@@ -6,9 +8,30 @@ import { Card } from '../Card'
 import { CardHotkeyBadge } from '../CardHotkeyBadge'
 import { CardPlace } from '../CardPlace'
 
+/**
+ * Shown on the deck place when the face-down deck is exhausted: clicking it
+ * turns the open pile over into a fresh deck. Clicks fall through to the
+ * (invisible, but clickable) deck card underneath.
+ */
+const ReshuffleHint = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: 'white',
+  pointerEvents: 'none',
+  fontSize: '3rem',
+  [theme.breakpoints.down('sm')]: {
+    fontSize: '2rem',
+  },
+}))
+
 export interface CardsStackProps {
   stackOpenDeckCard?: PlayerCard
   stackDeckCards: PlayerCard[]
+  /** The deck's `isHidden` flag from the game data: the closed pile lies face down. */
+  isStackDeckHidden: boolean
   onStackOpenDeckCardClick: () => void
   onStackDeckCardClick: () => void
   onStackDeckCardOutsideClick: () => void
@@ -17,11 +40,13 @@ export interface CardsStackProps {
   isStackOpenDeckDarkened: boolean
   isStackDeckHighlighted?: boolean
   ref?: Ref<HTMLDivElement>
+  dataTestId?: string
 }
 
 export const CardsStack = ({
   stackOpenDeckCard,
   stackDeckCards,
+  isStackDeckHidden,
   onStackOpenDeckCardClick,
   onStackDeckCardClick,
   onStackDeckCardOutsideClick,
@@ -30,10 +55,11 @@ export const CardsStack = ({
   isStackOpenDeckDarkened,
   isStackDeckHighlighted,
   ref,
+  dataTestId,
 }: CardsStackProps) => (
-  <CardsRow ref={ref}>
+  <CardsRow ref={ref} dataTestId={dataTestId}>
     <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.x : undefined}>
-      <CardPlace>
+      <CardPlace dataTestId={dataTestId ? `${dataTestId}-OpenDeck` : undefined}>
         {stackOpenDeckCard && (
           <Card
             {...stackOpenDeckCard}
@@ -47,8 +73,18 @@ export const CardsStack = ({
     </CardHotkeyBadge>
 
     <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.space : undefined}>
-      <CardPlace>
-        <Card color={stackDeckCards[0]?.color} onClick={onStackDeckCardClick} isHighlighted={isStackDeckHighlighted} />
+      <CardPlace dataTestId={dataTestId ? `${dataTestId}-Deck` : undefined}>
+        <Card
+          {...stackDeckCards[0]}
+          isHidden={isStackDeckHidden && stackDeckCards.length > 0}
+          onClick={onStackDeckCardClick}
+          isHighlighted={isStackDeckHighlighted}
+        />
+        {stackDeckCards.length === 0 && stackOpenDeckCard ? (
+          <ReshuffleHint>
+            <CachedIcon fontSize="inherit" />
+          </ReshuffleHint>
+        ) : null}
       </CardPlace>
     </CardHotkeyBadge>
   </CardsRow>

--- a/apps/ligretto-frontend/src/features/player/ui/LigrettoDeckContainer.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/LigrettoDeckContainer.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { isDndEnabledSelector, tapLigrettoDeckCardAction, playerLigrettoDeckCardsSelector } from '#ducks/game'
+import { isDndEnabledSelector, tapLigrettoDeckCardAction, playerLigrettoDeckCardsSelector, playerLigrettoDeckHiddenSelector } from '#ducks/game'
 import { LigrettoPack } from './LigrettoPack'
 
 export const LigrettoDeckContainer = () => {
   const dispatch = useDispatch()
   const isDndEnabled = useSelector(isDndEnabledSelector)
   const ligrettoDeckCards = useSelector(playerLigrettoDeckCardsSelector)
+  const isDeckHidden = useSelector(playerLigrettoDeckHiddenSelector)
 
   const onLigrettoDeckCardClick = useCallback(() => {
     dispatch(tapLigrettoDeckCardAction())
@@ -21,6 +22,7 @@ export const LigrettoDeckContainer = () => {
       count={ligrettoDeckCards.length}
       isDndEnabled={isDndEnabled}
       ligrettoDeckCards={ligrettoDeckCards}
+      isDeckHidden={isDeckHidden ?? true}
       onLigrettoDeckCardClick={onLigrettoDeckCardClick}
     />
   )

--- a/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/LigrettoPack/LigrettoPack.tsx
@@ -11,29 +11,40 @@ interface LigrettoPackProps {
   count: number
   isDndEnabled: boolean
   ligrettoDeckCards: PlayerCards[]
+  /** The deck's `isHidden` flag from the game data: the ligretto deck lies face down. */
+  isDeckHidden: boolean
   onLigrettoDeckCardClick: () => void
   isHighlighted?: boolean
   isDisabled?: boolean
   ref?: Ref<HTMLDivElement>
+  dataTestId?: string
 }
 
 export const LigrettoPack = ({
   count,
   isDndEnabled,
   ligrettoDeckCards,
+  isDeckHidden,
   onLigrettoDeckCardClick,
   isHighlighted,
   isDisabled,
   ref,
+  dataTestId,
 }: LigrettoPackProps) => (
-  <div ref={ref} className={styles.ligrettoPack}>
+  <div ref={ref} data-test-id={dataTestId} className={styles.ligrettoPack}>
     <div className={styles.cardWrapper}>
       <CardHotkeyBadge hotkey={isDndEnabled ? Hotkey.l : undefined}>
         <CardPlace>
-          <Card color={ligrettoDeckCards[0]?.color} onClick={onLigrettoDeckCardClick} isHighlighted={isHighlighted} isDisabled={isDisabled} />
+          <Card
+            {...ligrettoDeckCards[0]}
+            isHidden={isDeckHidden && ligrettoDeckCards.length > 0}
+            onClick={onLigrettoDeckCardClick}
+            isHighlighted={isHighlighted}
+            isDisabled={isDisabled}
+          />
         </CardPlace>
       </CardHotkeyBadge>
     </div>
-    <Typography sx={{ fontSize: { xs: '0.375rem', sm: '1rem' } }}>В колоде: {count}</Typography>
+    <Typography sx={{ fontSize: { xs: '0.625rem', sm: '1rem' } }}>В колоде: {count}</Typography>
   </div>
 )

--- a/apps/ligretto-frontend/src/features/player/ui/PlayerCardsStack/PlayerCardsStack.selector.ts
+++ b/apps/ligretto-frontend/src/features/player/ui/PlayerCardsStack/PlayerCardsStack.selector.ts
@@ -1,12 +1,19 @@
 import { createSelector } from '@reduxjs/toolkit'
 
-import { isDndEnabledSelector, playerStackDeckCardsSelector, playerStackOpenDeckCardsSelector, selectedCardIndexSelector } from '#ducks/game'
+import {
+  isDndEnabledSelector,
+  playerStackDeckCardsSelector,
+  playerStackDeckHiddenSelector,
+  playerStackOpenDeckCardsSelector,
+  selectedCardIndexSelector,
+} from '#ducks/game'
 
 export const playerCardsStackSelector = createSelector(
-  [playerStackOpenDeckCardsSelector, playerStackDeckCardsSelector, isDndEnabledSelector, selectedCardIndexSelector],
-  (stackOpenDeckCards, stackDeckCards, isDndEnabled, selectedCardIndex) => ({
+  [playerStackOpenDeckCardsSelector, playerStackDeckCardsSelector, playerStackDeckHiddenSelector, isDndEnabledSelector, selectedCardIndexSelector],
+  (stackOpenDeckCards, stackDeckCards, isStackDeckHidden, isDndEnabled, selectedCardIndex) => ({
     stackOpenDeckCard: stackOpenDeckCards?.[stackOpenDeckCards.length - 1],
     stackDeckCards,
+    isStackDeckHidden: isStackDeckHidden ?? true,
     isDndEnabled,
     selectedCardIndex,
   }),

--- a/apps/ligretto-frontend/src/features/player/ui/PlayerCardsStack/PlayerCardsStack.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/PlayerCardsStack/PlayerCardsStack.tsx
@@ -7,7 +7,7 @@ import { playerCardsStackSelector } from './PlayerCardsStack.selector'
 
 export const PlayerCardsStack = () => {
   const dispatch = useDispatch()
-  const { stackDeckCards, stackOpenDeckCard, isDndEnabled, selectedCardIndex } = useSelector(playerCardsStackSelector)
+  const { stackDeckCards, isStackDeckHidden, stackOpenDeckCard, isDndEnabled, selectedCardIndex } = useSelector(playerCardsStackSelector)
 
   const handleStackOpenDeckCardClick = useCallback(() => {
     dispatch(tapStackOpenDeckCardAction())
@@ -29,6 +29,7 @@ export const PlayerCardsStack = () => {
     <CardsStack
       stackOpenDeckCard={stackOpenDeckCard}
       stackDeckCards={stackDeckCards}
+      isStackDeckHidden={isStackDeckHidden}
       onStackOpenDeckCardClick={handleStackOpenDeckCardClick}
       onStackDeckCardOutsideClick={handleStackOpenDeckCardOutsideClick}
       onStackDeckCardClick={handleStackDeckCardClick}

--- a/apps/ligretto-frontend/src/shared/ui/OnboardingArrow/OnboardingArrow.tsx
+++ b/apps/ligretto-frontend/src/shared/ui/OnboardingArrow/OnboardingArrow.tsx
@@ -53,7 +53,10 @@ export function OnboardingArrow({
   const points = useElementAnchorPoints(from, to, containerRef, fromAnchor, toAnchor)
 
   return (
-    <div ref={containerRef} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>
+    // zIndex matches the description bubble: an arrow is part of the same decoration and has to
+    // stay above the raised game layers it points at. The svg is inflated by PADDING on every
+    // side, so it is clipped to the container to keep it from growing the page.
+    <div ref={containerRef} style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 2, overflow: 'hidden' }}>
       {points &&
         (() => {
           const { p1, p2 } = points

--- a/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/OnboardingOutline.stories.tsx
+++ b/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/OnboardingOutline.stories.tsx
@@ -4,25 +4,58 @@ import { OnboardingOutline } from './OnboardingOutline'
 
 const wrapStyle: CSSProperties = {
   background: '#3d9970',
-  padding: 24,
+  padding: 48,
   display: 'inline-flex',
 }
+
+const outlineStyle = (width: number, height: number): CSSProperties => ({
+  position: 'relative',
+  width,
+  height,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 8,
+})
+
+const cardStyle: CSSProperties = {
+  width: 80,
+  height: 112,
+  borderRadius: 8,
+  background: 'rgba(255,255,255,0.25)',
+  border: '2px solid white',
+}
+
+/** The outline fills its parent, so the parent sizes the loop around the wrapped content. */
+const Demo = ({ width, height, cards }: { width: number; height: number; cards: number }) => (
+  <div style={wrapStyle}>
+    <div style={outlineStyle(width, height)}>
+      {Array.from({ length: cards }, (_, index) => (
+        <div key={index} style={cardStyle} />
+      ))}
+      <div style={{ position: 'absolute', inset: 0 }}>
+        <OnboardingOutline />
+      </div>
+    </div>
+  </div>
+)
 
 const meta: Meta<typeof OnboardingOutline> = {
   title: 'Ligretto / OnboardingOutline',
   component: OnboardingOutline,
-  decorators: [
-    Story => (
-      <div style={wrapStyle}>
-        <Story />
-      </div>
-    ),
-  ],
 }
 export default meta
 
 type Story = StoryObj<typeof OnboardingOutline>
 
 export const DefaultView: Story = {
-  render: () => <OnboardingOutline />,
+  render: () => <Demo width={273} height={243} cards={1} />,
+}
+
+export const AroundSingleCard: Story = {
+  render: () => <Demo width={128} height={160} cards={1} />,
+}
+
+export const AroundCardsRow: Story = {
+  render: () => <Demo width={340} height={168} cards={3} />,
 }

--- a/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/OnboardingOutline.tsx
+++ b/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/OnboardingOutline.tsx
@@ -1,10 +1,28 @@
+/**
+ * Hand-drawn loop that circles a highlighted element.
+ *
+ * Fills its parent, so the parent's box defines what the loop wraps: the
+ * drawing is stretched (`preserveAspectRatio="none"`) while the stroke keeps a
+ * constant width (`vectorEffect="non-scaling-stroke"`).
+ *
+ * Figma: https://www.figma.com/design/zLXO12ISnORKAut0uduasj/Ligretto?node-id=1036-348
+ */
 export function OnboardingOutline() {
   return (
-    <svg width="273" height="243" viewBox="0 0 273 243" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 273 243"
+      preserveAspectRatio="none"
+      fill="none"
+      style={{ display: 'block', overflow: 'visible' }}
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
         d="M133.011 11.6175C95.6207 8.98742 13.5021 30.554 3.01866 103.144C-9.79397 191.862 36.9908 264.523 183.005 234.507C323.083 205.711 291.308 -4.16294 121.479 1.09719"
         stroke="white"
-        stroke-width="2"
+        strokeWidth={2}
+        vectorEffect="non-scaling-stroke"
       />
     </svg>
   )

--- a/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/index.ts
+++ b/apps/ligretto-frontend/src/shared/ui/OnboardingOutline/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingOutline } from './OnboardingOutline'


### PR DESCRIPTION
Первая независимая часть #611: изменения карточных и декоративных компонентов, без самого онбординга. Работает поверх master сама по себе.

- **Card**: проп `isHidden` — карта, лежащая рубашкой вверх, рисует единую рубашку (`CardBackFace`, SVG) вместо лица; фон-цвет лица при этом отключён и не просвечивает по скруглённым углам рубашки.
- **CardsStack**: закрытая колода в руке рендерится рубашкой — флаг `isHidden` приходит из данных деки (`CardsDeck.isHidden`); когда закрытая колода пуста, на её месте иконка перелистывания ⟳ (клик переворачивает открытую стопку). **Добавлен сторибук** (5 стейтов: рубашка, открытая карта, подсветка, выбранная карта, пустая колода с иконкой).
- **LigrettoPack**: колода Лигретто тоже лежит рубашкой вверх (`isDeckHidden` из данных). Раньше «рубашка» обеих колод красилась в цвет верхней скрытой карты и подсказывала его. Заодно счётчик «В колоде» на телефоне 0.625rem вместо нечитаемых 0.375rem.
- **Селекторы** `playerStackDeckHiddenSelector` / `playerLigrettoDeckHiddenSelector`, прокинуты через `PlayerCardsStack` и `LigrettoDeckContainer`.
- **CardPlace / CardsRow / CardsStack / LigrettoPack**: проп `dataTestId` для e2e-хуков.
- **OnboardingArrow**: zIndex + клиппинг svg (декорация не растит страницу); **OnboardingOutline**: рисованная обводка растягивается по родителю с постоянной толщиной штриха, сторибук переписан, добавлен index-экспорт.

Проверено против master: ts-check, unit (19), oxlint/oxfmt.

После мержа перебазирую #611 — его дифф уменьшится на эти файлы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)