### PR TITLE
fix(ligretto): починить сборку образа ligretto-core-backend

### DIFF
--- a/.docker/Ligretto-core-backend_Dockerfile
+++ b/.docker/Ligretto-core-backend_Dockerfile
@@ -8,6 +8,10 @@ WORKDIR /memebattle
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /memebattle/
 COPY packages/ligretto-shared/package.json /memebattle/packages/ligretto-shared/
 COPY packages/cas-services/package.json /memebattle/packages/cas-services/
+# Its committed dist/ too: injectWorkspacePackages copies the publishable files of a workspace
+# dep into the virtual store at install time and never refreshes them, so a manifest-only copy
+# leaves the injected @memebattle/cas-services empty and the app build cannot resolve it.
+COPY packages/cas-services/dist/ /memebattle/packages/cas-services/dist/
 COPY apps/ligretto-core-backend/package.json /memebattle/apps/ligretto-core-backend/
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
@@ -30,4 +34,4 @@ USER node
 COPY --chown=node:node --from=build /prod /ligretto-core-backend
 WORKDIR /ligretto-core-backend
 
-ENTRYPOINT [ "node", "build/server.js" ]
+ENTRYPOINT [ "node", "build/bin/server.js" ]

--- a/.github/workflows/ligretto-deploy.yml
+++ b/.github/workflows/ligretto-deploy.yml
@@ -76,8 +76,8 @@ jobs:
             ghcr.io/memebattle/ligretto-gameplay-backend:latest
           context: '.'
           file: '.docker/Ligretto-gameplay-backend_Dockerfile'
-          cache-from: type=gha,scope=$GITHUB_REF_NAME-ligretto-gameplay-backend
-          cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-ligretto-gameplay-backend
+          cache-from: type=gha,scope=${{ github.ref_name }}-ligretto-gameplay-backend
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-ligretto-gameplay-backend
 
   ligretto-core-backend-image:
     runs-on: ubuntu-24.04
@@ -108,8 +108,8 @@ jobs:
             ghcr.io/memebattle/ligretto-core-backend:latest
           context: '.'
           file: '.docker/Ligretto-core-backend_Dockerfile'
-          cache-from: type=gha,scope=$GITHUB_REF_NAME-ligretto-core-backend
-          cache-to: type=gha,mode=max,scope=$GITHUB_REF_NAME-ligretto-core-backend
+          cache-from: type=gha,scope=${{ github.ref_name }}-ligretto-core-backend
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-ligretto-core-backend
 
   deploy-ligretto-core-backend:
     name: Deploy Ligretto Core Backend

--- a/.github/workflows/ligretto-pr.yml
+++ b/.github/workflows/ligretto-pr.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/ligretto-**'
       - 'packages/ligretto-shared/**'
       - 'packages/auth-front/**'
+      - 'packages/cas-services/**'
       - 'packages/ui/**'
       - '.docker/Ligretto-**'
       - .github/workflows/ligretto-pr.yml
@@ -47,6 +48,54 @@ jobs:
 
       - name: TS check
         run: pnpm ligretto:ts-check:ci
+
+  # Same Dockerfiles the release workflow pushes, built without pushing: the image build runs
+  # `pnpm install` and the production app build, neither of which the other PR jobs cover.
+  core-backend-image:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          push: false
+          context: '.'
+          file: '.docker/Ligretto-core-backend_Dockerfile'
+          cache-from: |
+            type=gha,scope=ligretto-core-backend-pr
+            type=gha,scope=${{ github.base_ref }}-ligretto-core-backend
+          cache-to: type=gha,mode=max,scope=ligretto-core-backend-pr
+
+  gameplay-backend-image:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          push: false
+          context: '.'
+          file: '.docker/Ligretto-gameplay-backend_Dockerfile'
+          cache-from: |
+            type=gha,scope=ligretto-gameplay-backend-pr
+            type=gha,scope=${{ github.base_ref }}-ligretto-gameplay-backend
+          cache-to: type=gha,mode=max,scope=ligretto-gameplay-backend-pr
 
   e2e:
     env:

--- a/apps/ligretto-core-backend/chart/templates/migration-job.yaml
+++ b/apps/ligretto-core-backend/chart/templates/migration-job.yaml
@@ -22,8 +22,8 @@ spec:
         - name: {{ .Chart.Name }}-migration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          workingDir: /memebattle/apps/ligretto-core-backend
-          command: ["node", "ace", "migration:run", "--force"]
+          workingDir: /ligretto-core-backend
+          command: ["node", "build/ace.js", "migration:run", "--force"]
           env:
             - name: LIGRETTO_CORE_APP_KEY
               valueFrom:

--- a/apps/ligretto-core-backend/package.json
+++ b/apps/ligretto-core-backend/package.json
@@ -25,7 +25,7 @@
     "#transformers/*": "./app/transformers/*.js"
   },
   "scripts": {
-    "build": "node ace build --production",
+    "build": "node ace build",
     "start": "node server.js",
     "start:dev": "NODE_ENV=development node ace serve --watch",
     "migrate": "node ace migration:run --force",
@@ -61,7 +61,7 @@
     "better-sqlite3": "catalog:",
     "cpx": "catalog:",
     "pino-pretty": "catalog:",
-    "typescript": "catalog:",
+    "typescript": "catalog:adonis",
     "youch": "catalog:",
     "youch-terminal": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
   injectWorkspacePackages: true
 
 catalogs:
+  adonis:
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
   default:
     '@adonisjs/assembler':
       specifier: 8.4.0
@@ -649,13 +653,13 @@ importers:
     dependencies:
       '@adonisjs/core':
         specifier: 'catalog:'
-        version: 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
+        version: 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
       '@adonisjs/cors':
         specifier: 'catalog:'
-        version: 3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))
+        version: 3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))
       '@adonisjs/lucid':
         specifier: 'catalog:'
-        version: 22.4.2(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@13.0.1)(luxon@3.7.2)(pg@8.22.0)(supports-color@10.2.2)
+        version: 22.4.2(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@13.0.1)(luxon@3.7.2)(pg@8.22.0)(supports-color@10.2.2)
       '@codexsoft/dotenv-flow':
         specifier: 'catalog:'
         version: 3.3.5
@@ -686,7 +690,7 @@ importers:
     devDependencies:
       '@adonisjs/assembler':
         specifier: 'catalog:'
-        version: 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+        version: 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       '@adonisjs/tsconfig':
         specifier: 'catalog:'
         version: 2.0.0
@@ -698,7 +702,7 @@ importers:
         version: 4.2.0(@japa/runner@5.3.0)
       '@japa/plugin-adonisjs':
         specifier: 'catalog:'
-        version: 5.2.0(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@5.5.0))(@japa/runner@5.3.0)(playwright@1.62.0)
+        version: 5.2.0(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@5.5.0))(@japa/runner@5.3.0)(playwright@1.62.0)
       '@japa/runner':
         specifier: 'catalog:'
         version: 5.3.0
@@ -721,8 +725,8 @@ importers:
         specifier: 'catalog:'
         version: 13.1.3
       typescript:
-        specifier: 'catalog:'
-        version: 7.0.2
+        specifier: catalog:adonis
+        version: 5.9.3
       youch:
         specifier: 'catalog:'
         version: 4.1.1
@@ -8703,6 +8707,11 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -9140,7 +9149,7 @@ snapshots:
       yargs-parser: 22.0.0
       youch: 4.1.1
 
-  '@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)':
+  '@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)':
     dependencies:
       '@adonisjs/config': 6.1.0
       '@adonisjs/fold': 11.0.0
@@ -9150,9 +9159,9 @@ snapshots:
       glob-parent: 6.0.2
       tempura: 0.4.1
     optionalDependencies:
-      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
 
-  '@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)':
+  '@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@adonisjs/env': 7.0.0
       '@antfu/install-pkg': 1.1.0
@@ -9175,13 +9184,13 @@ snapshots:
       pretty-hrtime: 1.0.3
       tmp-cache: 1.1.0
       ts-morph: 27.0.2
-      typescript: 7.0.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@adonisjs/bodyparser@11.0.4(@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1))(supports-color@5.5.0)':
+  '@adonisjs/bodyparser@11.0.4(@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1))(supports-color@5.5.0)':
     dependencies:
-      '@adonisjs/http-server': 9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)
+      '@adonisjs/http-server': 9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)
       '@poppinss/macroable': 1.1.2
       '@poppinss/middleware': 3.2.7
       '@poppinss/multiparty': 3.0.0
@@ -9198,18 +9207,18 @@ snapshots:
     dependencies:
       '@poppinss/utils': 7.0.1
 
-  '@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)':
+  '@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)':
     dependencies:
       '@adonisjs/ace': 14.1.0(youch@4.1.1)
-      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
-      '@adonisjs/bodyparser': 11.0.4(@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1))(supports-color@5.5.0)
+      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
+      '@adonisjs/bodyparser': 11.0.4(@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1))(supports-color@5.5.0)
       '@adonisjs/config': 6.1.0
       '@adonisjs/env': 7.0.0
-      '@adonisjs/events': 10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)
+      '@adonisjs/events': 10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)
       '@adonisjs/fold': 11.0.0
       '@adonisjs/hash': 10.1.0
       '@adonisjs/health': 3.1.0
-      '@adonisjs/http-server': 9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)
+      '@adonisjs/http-server': 9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)
       '@adonisjs/http-transformers': 2.3.1(@adonisjs/fold@11.0.0)
       '@adonisjs/logger': 7.1.1(pino-pretty@13.1.3)
       '@adonisjs/repl': 5.0.0
@@ -9225,18 +9234,18 @@ snapshots:
       pretty-hrtime: 1.0.3
       string-width: 8.2.2
     optionalDependencies:
-      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       '@vinejs/vine': 4.4.0
       pino-pretty: 13.1.3
       youch: 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@adonisjs/cors@3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))':
+  '@adonisjs/cors@3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))':
     dependencies:
-      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
+      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
     optionalDependencies:
-      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
 
   '@adonisjs/env@7.0.0':
     dependencies:
@@ -9244,9 +9253,9 @@ snapshots:
       '@poppinss/validator-lite': 2.1.2
       split-lines: 3.0.0
 
-  '@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)':
+  '@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)':
     dependencies:
-      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
+      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
       '@adonisjs/fold': 11.0.0
       '@poppinss/utils': 7.0.1
       '@sindresorhus/is': 7.2.0
@@ -9267,10 +9276,10 @@ snapshots:
       '@poppinss/utils': 7.0.1
       check-disk-space: 3.4.0
 
-  '@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)':
+  '@adonisjs/http-server@9.1.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/events@10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)(@adonisjs/logger@7.1.1(pino-pretty@13.1.3))(@boringnode/encryption@1.0.0)(youch@4.1.1)':
     dependencies:
-      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
-      '@adonisjs/events': 10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)
+      '@adonisjs/application': 9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0)
+      '@adonisjs/events': 10.2.0(@adonisjs/application@9.0.1(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/config@6.1.0)(@adonisjs/fold@11.0.0))(@adonisjs/fold@11.0.0)
       '@adonisjs/fold': 11.0.0
       '@adonisjs/logger': 7.1.1(pino-pretty@13.1.3)
       '@boringnode/encryption': 1.0.0
@@ -9309,10 +9318,10 @@ snapshots:
     optionalDependencies:
       pino-pretty: 13.1.3
 
-  '@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@13.0.1)(luxon@3.7.2)(pg@8.22.0)(supports-color@10.2.2)':
+  '@adonisjs/lucid@22.4.2(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@vinejs/vine@4.4.0)(better-sqlite3@13.0.1)(luxon@3.7.2)(pg@8.22.0)(supports-color@10.2.2)':
     dependencies:
-      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
-      '@adonisjs/presets': 3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))
+      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
+      '@adonisjs/presets': 3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))
       '@faker-js/faker': 10.4.0
       '@poppinss/hooks': 7.3.0
       '@poppinss/macroable': 1.1.2
@@ -9328,7 +9337,7 @@ snapshots:
       slash: 5.1.0
       tarn: 3.0.2
     optionalDependencies:
-      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
       '@vinejs/vine': 4.4.0
       luxon: 3.7.2
     transitivePeerDependencies:
@@ -9343,11 +9352,11 @@ snapshots:
       - supports-color
       - tedious
 
-  '@adonisjs/presets@3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))':
+  '@adonisjs/presets@3.0.0(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))':
     dependencies:
-      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
+      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
     optionalDependencies:
-      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2)
+      '@adonisjs/assembler': 8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3)
 
   '@adonisjs/repl@5.0.0':
     dependencies:
@@ -10206,9 +10215,9 @@ snapshots:
       supports-color: 10.2.2
       youch: 4.1.1
 
-  '@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@5.5.0))(@japa/runner@5.3.0)(playwright@1.62.0)':
+  '@japa/plugin-adonisjs@5.2.0(@adonisjs/core@7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1))(@japa/api-client@3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@5.5.0))(@japa/runner@5.3.0)(playwright@1.62.0)':
     dependencies:
-      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@7.0.2))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
+      '@adonisjs/core': 7.3.5(@adonisjs/assembler@8.4.0(babel-plugin-macros@3.1.0)(typescript@5.9.3))(@vinejs/vine@4.4.0)(pino-pretty@13.1.3)(supports-color@5.5.0)(youch@4.1.1)
       '@japa/runner': 5.3.0
     optionalDependencies:
       '@japa/api-client': 3.2.1(@japa/assert@4.2.0(@japa/runner@5.3.0))(@japa/runner@5.3.0)(supports-color@5.5.0)
@@ -16940,6 +16949,8 @@ snapshots:
 
   typedarray@0.0.6:
     optional: true
+
+  typescript@5.9.3: {}
 
   typescript@7.0.2:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,10 +26,13 @@ overrides:
 # binaries or optional native addons and the repo has never needed their scripts.
 allowBuilds:
   '@swc/core': true
-  better-sqlite3: true
   contentlayer: true
   esbuild: true
   protobufjs: true
+  # better-sqlite3 has no install script but ships binding.gyp, so pnpm implicitly
+  # runs `node-gyp rebuild` when builds are allowed — that needs Python, which the
+  # slim node image lacks. It ships prebuilds/ for every platform we use, so skip it.
+  better-sqlite3: false
   '@parcel/watcher': false
   '@sentry/cli': false
   core-js: false
@@ -156,6 +159,14 @@ catalog:
   wait-on: ^9.1.0
   youch: 4.1.1
   youch-terminal: 2.2.3
+
+# @adonisjs/assembler (peer `typescript: ^5.0.0 || ^6.0.0`) drives `node ace build` through
+# the TypeScript JS API, which TS 7 dropped — `ts.getParsedCommandLineOfConfigFile` is gone.
+# ligretto-core-backend stays on TS 5 until Adonis supports the native compiler.
+catalogs:
+  adonis:
+    typescript: ^5.9.3
+
 catalogMode: strict
 
 cleanupUnusedCatalogs: true
@@ -165,157 +176,3 @@ cleanupUnusedCatalogs: true
 # of quietly putting it in the lockfile for every later install to trip over.
 # Pin an exception in minimumReleaseAgeExclude when a fresh release is actually needed.
 minimumReleaseAge: 10080
-
-# Grandfathered: these exact versions were resolved under pnpm 10, before any release-age
-# policy existed, and the week-long window would otherwise reject the lockfile we already
-# ship. Every entry here is older than a day and the newest (chalk@6.0.0) clears the window
-# on 2026-08-02 — drop this whole block once it does. New exceptions go here one at a time,
-# pinned to an exact version, never to a bare package name.
-minimumReleaseAgeExclude:
-  - '@amplitude/analytics-browser@2.45.4'
-  - '@amplitude/analytics-core@2.54.0'
-  - '@amplitude/plugin-autocapture-browser@1.28.9'
-  - '@amplitude/plugin-custom-enrichment-browser@0.1.19'
-  - '@amplitude/plugin-event-property-attribution-browser@0.2.11'
-  - '@amplitude/plugin-network-capture-browser@1.10.11'
-  - '@amplitude/plugin-page-url-enrichment-browser@0.7.21'
-  - '@amplitude/plugin-page-view-tracking-browser@2.11.11'
-  - '@amplitude/plugin-web-vitals-browser@1.1.43'
-  - '@csstools/css-calc@3.3.0'
-  - '@csstools/css-color-parser@4.1.10'
-  - '@csstools/css-syntax-patches-for-csstree@1.1.7'
-  - '@inversifyjs/container@3.1.3'
-  - '@inversifyjs/core@15.0.1'
-  - '@next/env@16.2.12'
-  - '@next/mdx@16.2.12'
-  - '@next/swc-darwin-arm64@16.2.12'
-  - '@next/swc-darwin-x64@16.2.12'
-  - '@next/swc-linux-arm64-gnu@16.2.12'
-  - '@next/swc-linux-arm64-musl@16.2.12'
-  - '@next/swc-linux-x64-gnu@16.2.12'
-  - '@next/swc-linux-x64-musl@16.2.12'
-  - '@next/swc-win32-arm64-msvc@16.2.12'
-  - '@next/swc-win32-x64-msvc@16.2.12'
-  - '@oxfmt/binding-android-arm-eabi@0.60.0'
-  - '@oxfmt/binding-android-arm64@0.60.0'
-  - '@oxfmt/binding-darwin-arm64@0.60.0'
-  - '@oxfmt/binding-darwin-x64@0.60.0'
-  - '@oxfmt/binding-freebsd-x64@0.60.0'
-  - '@oxfmt/binding-linux-arm-gnueabihf@0.60.0'
-  - '@oxfmt/binding-linux-arm-musleabihf@0.60.0'
-  - '@oxfmt/binding-linux-arm64-gnu@0.60.0'
-  - '@oxfmt/binding-linux-arm64-musl@0.60.0'
-  - '@oxfmt/binding-linux-ppc64-gnu@0.60.0'
-  - '@oxfmt/binding-linux-riscv64-gnu@0.60.0'
-  - '@oxfmt/binding-linux-riscv64-musl@0.60.0'
-  - '@oxfmt/binding-linux-s390x-gnu@0.60.0'
-  - '@oxfmt/binding-linux-x64-gnu@0.60.0'
-  - '@oxfmt/binding-linux-x64-musl@0.60.0'
-  - '@oxfmt/binding-openharmony-arm64@0.60.0'
-  - '@oxfmt/binding-win32-arm64-msvc@0.60.0'
-  - '@oxfmt/binding-win32-ia32-msvc@0.60.0'
-  - '@oxfmt/binding-win32-x64-msvc@0.60.0'
-  - '@oxlint-tsgolint/darwin-arm64@7.0.2001'
-  - '@oxlint-tsgolint/darwin-x64@7.0.2001'
-  - '@oxlint-tsgolint/linux-arm64@7.0.2001'
-  - '@oxlint-tsgolint/linux-x64@7.0.2001'
-  - '@oxlint-tsgolint/win32-arm64@7.0.2001'
-  - '@oxlint-tsgolint/win32-x64@7.0.2001'
-  - '@oxlint/binding-android-arm-eabi@1.75.0'
-  - '@oxlint/binding-android-arm64@1.75.0'
-  - '@oxlint/binding-darwin-arm64@1.75.0'
-  - '@oxlint/binding-darwin-x64@1.75.0'
-  - '@oxlint/binding-freebsd-x64@1.75.0'
-  - '@oxlint/binding-linux-arm-gnueabihf@1.75.0'
-  - '@oxlint/binding-linux-arm-musleabihf@1.75.0'
-  - '@oxlint/binding-linux-arm64-gnu@1.75.0'
-  - '@oxlint/binding-linux-arm64-musl@1.75.0'
-  - '@oxlint/binding-linux-ppc64-gnu@1.75.0'
-  - '@oxlint/binding-linux-riscv64-gnu@1.75.0'
-  - '@oxlint/binding-linux-riscv64-musl@1.75.0'
-  - '@oxlint/binding-linux-s390x-gnu@1.75.0'
-  - '@oxlint/binding-linux-x64-gnu@1.75.0'
-  - '@oxlint/binding-linux-x64-musl@1.75.0'
-  - '@oxlint/binding-openharmony-arm64@1.75.0'
-  - '@oxlint/binding-win32-arm64-msvc@1.75.0'
-  - '@oxlint/binding-win32-ia32-msvc@1.75.0'
-  - '@oxlint/binding-win32-x64-msvc@1.75.0'
-  - '@playwright/test@1.62.0'
-  - '@radix-ui/primitive@1.1.7'
-  - '@radix-ui/react-arrow@1.1.15'
-  - '@radix-ui/react-collection@1.1.15'
-  - '@radix-ui/react-compose-refs@1.1.5'
-  - '@radix-ui/react-context@1.2.2'
-  - '@radix-ui/react-direction@1.1.4'
-  - '@radix-ui/react-dismissable-layer@1.1.19'
-  - '@radix-ui/react-dropdown-menu@2.1.24'
-  - '@radix-ui/react-focus-guards@1.1.6'
-  - '@radix-ui/react-focus-scope@1.1.16'
-  - '@radix-ui/react-id@1.1.4'
-  - '@radix-ui/react-menu@2.1.24'
-  - '@radix-ui/react-popover@1.1.23'
-  - '@radix-ui/react-popper@1.3.7'
-  - '@radix-ui/react-portal@1.1.17'
-  - '@radix-ui/react-presence@1.1.10'
-  - '@radix-ui/react-primitive@2.1.10'
-  - '@radix-ui/react-roving-focus@1.1.19'
-  - '@radix-ui/react-slot@1.3.3'
-  - '@radix-ui/react-use-callback-ref@1.1.4'
-  - '@radix-ui/react-use-controllable-state@1.2.6'
-  - '@radix-ui/react-use-effect-event@0.0.5'
-  - '@radix-ui/react-use-is-hydrated@0.1.3'
-  - '@radix-ui/react-use-layout-effect@1.1.4'
-  - '@radix-ui/react-use-rect@1.1.4'
-  - '@radix-ui/react-use-size@1.1.4'
-  - '@radix-ui/rect@1.1.3'
-  - '@rsbuild/core@2.1.8'
-  - '@rspack/binding-darwin-arm64@2.1.5'
-  - '@rspack/binding-darwin-x64@2.1.5'
-  - '@rspack/binding-linux-arm64-gnu@2.1.5'
-  - '@rspack/binding-linux-arm64-musl@2.1.5'
-  - '@rspack/binding-linux-riscv64-gnu@2.1.5'
-  - '@rspack/binding-linux-riscv64-musl@2.1.5'
-  - '@rspack/binding-linux-x64-gnu@2.1.5'
-  - '@rspack/binding-linux-x64-musl@2.1.5'
-  - '@rspack/binding-wasm32-wasi@2.1.5'
-  - '@rspack/binding-win32-arm64-msvc@2.1.5'
-  - '@rspack/binding-win32-ia32-msvc@2.1.5'
-  - '@rspack/binding-win32-x64-msvc@2.1.5'
-  - '@rspack/binding@2.1.5'
-  - '@rspack/core@2.1.5'
-  - '@sentry/browser-utils@10.68.0'
-  - '@sentry/browser@10.68.0'
-  - '@sentry/bundler-plugins@10.68.0'
-  - '@sentry/core@10.68.0'
-  - '@sentry/feedback@10.68.0'
-  - '@sentry/replay-canvas@10.68.0'
-  - '@sentry/replay@10.68.0'
-  - '@storybook/addon-a11y@10.5.4'
-  - '@storybook/builder-vite@10.5.4'
-  - '@storybook/csf-plugin@10.5.4'
-  - '@storybook/react-dom-shim@10.5.4'
-  - '@storybook/react-vite@10.5.4'
-  - '@storybook/react@10.5.4'
-  - '@vitejs/plugin-react@6.0.4'
-  - 'better-sqlite3@13.0.1'
-  - 'chalk@6.0.0'
-  - 'chromatic@18.1.0'
-  - 'enhanced-resolve@5.24.3'
-  - 'html-parse-stringify@4.0.1'
-  - 'inversify@8.2.3'
-  - 'next@16.2.12'
-  - 'oxfmt@0.60.0'
-  - 'oxlint-tsgolint@7.0.2001'
-  - 'oxlint@1.75.0'
-  - 'playwright-core@1.62.0'
-  - 'playwright@1.62.0'
-  - 'postcss@8.5.23'
-  - 'react-dom@19.2.8'
-  - 'react-i18next@17.0.11'
-  - 'react-is@19.2.8'
-  - 'react-router@8.3.0'
-  - 'react@19.2.8'
-  - 'sass@1.102.0'
-  - 'storybook@10.5.4'
-  - 'undici@7.29.0'
-  - 'wait-on@9.1.0'


### PR DESCRIPTION
Образ `ligretto-core-backend` не собирался с #582 (Adonis v6 → v7), последняя успешная сборка — 16 февраля. Ошибка про `pnpm install` в логах мастера была только первой из четырёх: каждая следующая вскрывалась после починки предыдущей.

## Что чинится

| Ошибка | Причина |
|---|---|
| `node-gyp rebuild` падает без Python | у `better-sqlite3` нет install-скрипта, но есть `binding.gyp` — pnpm в таком случае неявно запускает node-gyp, если пакет разрешён в `allowBuilds`. Пакет везёт `prebuilds/` под все наши платформы, сборка из исходников не нужна |
| `Unknown flag "--production"` | в Adonis 7 флага у `ace build` больше нет |
| `ts.getParsedCommandLineOfConfigFile is not a function` | `@adonisjs/assembler` (peer `typescript: ^5 \|\| ^6`) ходит в JS API компилятора, которого в TS 7 нет. core-backend переведён на TS 5 через именованный каталог `adonis`, остальной репозиторий остаётся на TS 7 |
| `Cannot find module '@memebattle/cas-services'` | `injectWorkspacePackages` копирует публикуемые файлы workspace-зависимости в виртуальный стор **на install** и больше их не обновляет. На этапе `dependencies` в образе лежал только манифест, поэтому инжектированная копия оставалась без `dist/`, а `COPY .` её не чинит — она живёт в `node_modules/.pnpm` |

Второе и третье к Docker не привязаны — `pnpm ligretto:core-backend:build` падает так же локально.

Попутно два стёртых пути рантайма из того же апгрейда Adonis: точка входа переехала с `build/server.js` на `build/bin/server.js` (до #582 в приложении был `server.ts` в корне), а job миграций в helm-чарте ходил в `/memebattle/apps/ligretto-core-backend`, которого в образе нет вообще.

## Чтобы это не повторилось

Сборка обоих образов лигретто добавлена в проверки на PR — `push: false`, тот же Dockerfile, что пушит релиз. Сейчас образы не собираются нигде, кроме мастера, поэтому такие поломки и доезжали до релиза.

PR-джобы читают кеш релизных сборок в дополнение к своему. Для этого починен scope в релизном workflow: `$GITHUB_REF_NAME` в `with:` не раскрывается (GitHub не делает shell-подстановку), так что кеш лежал под литеральным именем — заменено на `${{ github.ref_name }}`.

В `paths` PR-workflow добавлен `packages/cas-services/**`: образы от него зависят, а PR, меняющий только его, воркфлоу не запускал. В релизном workflow триггеры не трогал — это уже изменение условий выката прода.

## Заодно

Удалён `minimumReleaseAgeExclude`: последняя запись (`chalk@6.0.0`) прошла недельное окно 2 августа, как и было записано в комментарии. Полная проверка 1729 записей проходит без списка.

## Проверка

Образ собран локально из чистого контекста (без `node_modules`, как при checkout в CI) с `--no-cache` — проходит целиком. Контейнер стартует и доходит до валидации env, `node build/ace.js list` в образе работает. Образ gameplay-backend тоже собран, чтобы новый job не оказался красным с первого запуска. `pnpm ts-check` для core-backend, `fmt:check`, `lint:check`, `pnpm install --frozen-lockfile` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
