### PR TITLE
feat(ligretto): show disconnected player state

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -22,9 +22,16 @@ const config: StorybookConfig = {
       define: { 'process.env': {} },
       plugins: [svgr()],
       resolve: {
+        // Workspace packages are aliased to sources: their injected dist copies
+        // live under node_modules, so vite would serve them without CJS interop
+        // and their deps would never be prebundled. The subpath alias must come
+        // before the bare package alias.
         alias: {
           '@memebattle/ui': path.resolve(root, 'packages/ui/src/index.ts'),
           '@memebattle/ligretto-shared': path.resolve(root, 'packages/ligretto-shared/src/index.ts'),
+          '@memebattle/cas-services/createFrontServices': path.resolve(root, 'packages/cas-services/src/createFrontServices.ts'),
+          '@memebattle/cas-services': path.resolve(root, 'packages/cas-services/src/index.ts'),
+          '@memebattle/auth-front': path.resolve(root, 'apps/auth-front/src/module.tsx'),
         },
       },
     })

--- a/apps/ligretto-frontend/src/entities/card/index.ts
+++ b/apps/ligretto-frontend/src/entities/card/index.ts
@@ -1,3 +1,3 @@
-export { Card } from './ui/Card'
+export { Card, tabletHeightBySize, mobileHeightBySize } from './ui/Card'
 export { CardPlace } from './ui/CardPlace'
 export { CardHotkeyBadge } from './ui/CardHotkeyBadge'

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -9,36 +9,43 @@ import { Opponent } from './Opponent'
 const opponentProps = {
   id: 'opponent-id',
   username: 'Opponent',
-  status: PlayerStatus.InGame,
   stackOpenDeckCards: [{ color: CardColors.blue, value: 3 }],
   cards: [{ color: CardColors.red, value: 5 }, null],
 }
 
 describe('Opponent connection state', () => {
-  it('dims the whole opponent and shows a connection indicator only while disconnected', () => {
-    const view = render(<Opponent {...opponentProps} isDisconnected />)
+  it('dims the opponent and cards while keeping the disconnected icon red', () => {
+    const view = render(<Opponent {...opponentProps} status={PlayerStatus.Disconnected} />)
 
     const disconnectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
     expect(disconnectedOpponent.dataset.connectionState).toBe('disconnected')
-    expect(getComputedStyle(disconnectedOpponent).filter).toContain('grayscale')
-    expect(Number(getComputedStyle(disconnectedOpponent).opacity)).toBeLessThan(1)
-    const connectionIcon = screen.getByRole('img', { name: 'Connection lost' })
-    expect(connectionIcon).toBeTruthy()
-    expect(getComputedStyle(connectionIcon).fontSize).toBe('0.75rem')
 
     const avatar = screen.getByRole('img', { name: 'Opponent' })
-    const avatarWrapper = avatar.parentElement?.parentElement
+    const filteredAvatar = avatar.parentElement?.parentElement
+    expect(getComputedStyle(filteredAvatar!).filter).toContain('grayscale')
+    expect(Number(getComputedStyle(filteredAvatar!).opacity)).toBeLessThan(1)
+
+    const cards = screen.getByTestId('opponent-cards')
+    expect(getComputedStyle(cards).filter).toContain('grayscale')
+    expect(Number(getComputedStyle(cards).opacity)).toBeLessThan(1)
+
+    const connectionIcon = screen.getByRole('img', { name: 'Connection lost' })
+    expect(getComputedStyle(connectionIcon).fontSize).toBe('0.75rem')
+    expect(getComputedStyle(connectionIcon).filter).not.toContain('grayscale')
+    expect(getComputedStyle(connectionIcon).color).toBe('rgb(211, 47, 47)')
+
+    const avatarWrapper = filteredAvatar?.parentElement
     expect(getComputedStyle(avatarWrapper!).height).toBe('100%')
     expect(getComputedStyle(avatarWrapper!).aspectRatio).toBe('1 / 1')
     expect(getComputedStyle(avatarWrapper!).flexShrink).toBe('1')
 
-    view.rerender(<Opponent {...opponentProps} />)
+    view.rerender(<Opponent {...opponentProps} status={PlayerStatus.InGame} />)
 
     const connectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
     const connectedAvatar = screen.getByRole('img', { name: 'Opponent' })
     expect(connectedAvatar.parentElement?.parentElement?.parentElement).toBe(connectedOpponent)
     expect(connectedOpponent.dataset.connectionState).toBe('online')
-    expect(getComputedStyle(connectedOpponent).filter).not.toContain('grayscale')
+    expect(getComputedStyle(screen.getByTestId('opponent-cards')).filter).not.toContain('grayscale')
     expect(screen.queryByRole('img', { name: 'Connection lost' })).toBeNull()
   })
 })

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { CardColors, PlayerStatus } from '@memebattle/ligretto-shared'
+import { describe, expect, it } from 'vitest'
+
+import { Opponent } from './Opponent'
+
+const opponentProps = {
+  id: 'opponent-id',
+  username: 'Opponent',
+  status: PlayerStatus.InGame,
+  stackOpenDeckCards: [{ color: CardColors.blue, value: 3 }],
+  cards: [{ color: CardColors.red, value: 5 }, null],
+}
+
+describe('Opponent connection state', () => {
+  it('dims the whole opponent and shows a connection indicator only while disconnected', () => {
+    const view = render(<Opponent {...opponentProps} isDisconnected />)
+
+    const disconnectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
+    expect(disconnectedOpponent.dataset.connectionState).toBe('disconnected')
+    expect(getComputedStyle(disconnectedOpponent).filter).toContain('grayscale')
+    expect(Number(getComputedStyle(disconnectedOpponent).opacity)).toBeLessThan(1)
+    const connectionIcon = screen.getByRole('img', { name: 'Connection lost' })
+    expect(connectionIcon).toBeTruthy()
+    expect(getComputedStyle(connectionIcon).fontSize).toBe('0.75rem')
+
+    const avatar = screen.getByRole('img', { name: 'Opponent' })
+    const avatarWrapper = avatar.parentElement?.parentElement
+    expect(getComputedStyle(avatarWrapper!).height).toBe('100%')
+    expect(getComputedStyle(avatarWrapper!).aspectRatio).toBe('1 / 1')
+    expect(getComputedStyle(avatarWrapper!).flexShrink).toBe('1')
+
+    view.rerender(<Opponent {...opponentProps} />)
+
+    const connectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
+    expect(connectedOpponent.dataset.connectionState).toBe('online')
+    expect(getComputedStyle(connectedOpponent).filter).not.toContain('grayscale')
+    expect(screen.queryByRole('img', { name: 'Connection lost' })).toBeNull()
+  })
+})

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -35,6 +35,8 @@ describe('Opponent connection state', () => {
     view.rerender(<Opponent {...opponentProps} />)
 
     const connectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
+    const connectedAvatar = screen.getByRole('img', { name: 'Opponent' })
+    expect(connectedAvatar.parentElement?.parentElement?.parentElement).toBe(connectedOpponent)
     expect(connectedOpponent.dataset.connectionState).toBe('online')
     expect(getComputedStyle(connectedOpponent).filter).not.toContain('grayscale')
     expect(screen.queryByRole('img', { name: 'Connection lost' })).toBeNull()

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -30,14 +30,18 @@ describe('Opponent connection state', () => {
     expect(Number(getComputedStyle(cards).opacity)).toBeLessThan(1)
 
     const connectionIcon = screen.getByRole('img', { name: 'Connection lost' })
-    expect(getComputedStyle(connectionIcon).fontSize).toBe('0.75rem')
+    const username = screen.getByText('Opponent')
+    const statusRow = username.parentElement
+    expect(connectionIcon.parentElement?.parentElement).toBe(statusRow)
+    expect(getComputedStyle(statusRow!).minWidth).toBe('0px')
+    expect(getComputedStyle(username).fontSize).toBe('0.75rem')
+    expect(getComputedStyle(connectionIcon).fontSize).toBe('1rem')
     expect(getComputedStyle(connectionIcon).filter).not.toContain('grayscale')
     expect(getComputedStyle(connectionIcon).color).toBe('rgb(211, 47, 47)')
 
-    const avatarWrapper = filteredAvatar?.parentElement
-    expect(getComputedStyle(avatarWrapper!).height).toBe('100%')
-    expect(getComputedStyle(avatarWrapper!).aspectRatio).toBe('1 / 1')
-    expect(getComputedStyle(avatarWrapper!).flexShrink).toBe('1')
+    expect(getComputedStyle(filteredAvatar!).height).toBe('100%')
+    expect(getComputedStyle(filteredAvatar!).aspectRatio).toBe('1 / 1')
+    expect(getComputedStyle(filteredAvatar!).flexShrink).toBe('0')
 
     view.rerender(<Opponent {...opponentProps} status={PlayerStatus.InGame} />)
 

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -60,13 +60,17 @@ describe('Opponent connection state', () => {
 })
 
 describe('Opponent mobile order', () => {
-  it('keeps the avatar on the left for even indexes and on the right for odd ones', () => {
-    const view = render(<Opponent {...opponentProps} status={PlayerStatus.InGame} index={0} />)
+  it('keeps the avatar on the left for odd opponents and on the right for even ones', () => {
+    render(
+      <div>
+        <Opponent {...opponentProps} id="opponent-1" username="First" status={PlayerStatus.InGame} />
+        <Opponent {...opponentProps} id="opponent-2" username="Second" status={PlayerStatus.InGame} />
+        <Opponent {...opponentProps} id="opponent-3" username="Third" status={PlayerStatus.InGame} />
+      </div>,
+    )
 
-    // xs values of responsive sx styles apply without a media query, so jsdom resolves them
-    expect(getComputedStyle(view.getByRole('group', { name: 'Opponent player' })).flexDirection).toBe('row')
-
-    view.rerender(<Opponent {...opponentProps} status={PlayerStatus.InGame} index={1} />)
-    expect(getComputedStyle(view.getByRole('group', { name: 'Opponent player' })).flexDirection).toBe('row-reverse')
+    expect(getComputedStyle(screen.getByRole('group', { name: 'First player' })).flexDirection).toBe('row')
+    expect(getComputedStyle(screen.getByRole('group', { name: 'Second player' })).flexDirection).toBe('row-reverse')
+    expect(getComputedStyle(screen.getByRole('group', { name: 'Third player' })).flexDirection).toBe('row')
   })
 })

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -47,7 +47,10 @@ describe('Opponent connection state', () => {
 
     const connectedOpponent = screen.getByRole('group', { name: 'Opponent player' })
     const connectedAvatar = screen.getByRole('img', { name: 'Opponent' })
-    expect(connectedAvatar.parentElement?.parentElement?.parentElement).toBe(connectedOpponent)
+    const connectedFrame = connectedAvatar.parentElement?.parentElement
+    expect(connectedFrame?.parentElement?.parentElement).toBe(connectedOpponent)
+    expect(getComputedStyle(connectedFrame!).aspectRatio).toBe('1 / 1')
+    expect(getComputedStyle(connectedFrame!).filter).not.toContain('grayscale')
     expect(connectedOpponent.dataset.connectionState).toBe('online')
     expect(getComputedStyle(screen.getByTestId('opponent-cards')).filter).not.toContain('grayscale')
     expect(screen.queryByRole('img', { name: 'Connection lost' })).toBeNull()

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.spec.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { CardColors, PlayerStatus } from '@memebattle/ligretto-shared'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { Opponent } from './Opponent'
+
+afterEach(cleanup)
 
 const opponentProps = {
   id: 'opponent-id',
@@ -54,5 +56,17 @@ describe('Opponent connection state', () => {
     expect(connectedOpponent.dataset.connectionState).toBe('online')
     expect(getComputedStyle(screen.getByTestId('opponent-cards')).filter).not.toContain('grayscale')
     expect(screen.queryByRole('img', { name: 'Connection lost' })).toBeNull()
+  })
+})
+
+describe('Opponent mobile order', () => {
+  it('keeps the avatar on the left for even indexes and on the right for odd ones', () => {
+    const view = render(<Opponent {...opponentProps} status={PlayerStatus.InGame} index={0} />)
+
+    // xs values of responsive sx styles apply without a media query, so jsdom resolves them
+    expect(getComputedStyle(view.getByRole('group', { name: 'Opponent player' })).flexDirection).toBe('row')
+
+    view.rerender(<Opponent {...opponentProps} status={PlayerStatus.InGame} index={1} />)
+    expect(getComputedStyle(view.getByRole('group', { name: 'Opponent player' })).flexDirection).toBe('row-reverse')
   })
 })

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
@@ -27,6 +27,6 @@ export const Connected: Story = {}
 
 export const Disconnected: Story = {
   args: {
-    isDisconnected: true,
+    status: PlayerStatus.Disconnected,
   },
 }

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { CardColors, PlayerStatus } from '@memebattle/ligretto-shared'
+
+import { Opponent } from './Opponent'
+
+const meta: Meta<typeof Opponent> = {
+  title: 'Ligretto / Opponent',
+  component: Opponent,
+  args: {
+    id: 'opponent-id',
+    username: 'Opponent',
+    status: PlayerStatus.InGame,
+    stackOpenDeckCards: [{ color: CardColors.blue, value: 3 }],
+    cards: [
+      { color: CardColors.red, value: 5 },
+      { color: CardColors.green, value: 7 },
+      { color: CardColors.yellow, value: 9 },
+    ],
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Opponent>
+
+export const Connected: Story = {}
+
+export const Disconnected: Story = {
+  args: {
+    isDisconnected: true,
+  },
+}

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
@@ -43,17 +43,10 @@ export const MobileOpponents: Story = {
     },
   },
   render: () => (
-    <Stack spacing={1} sx={{ width: '100%' }}>
-      <Opponent index={0} id="opponent-1" username="First" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
-      <Opponent index={1} id="opponent-2" username="Second" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
-      <Opponent
-        index={2}
-        id="opponent-3"
-        username="Disconnected"
-        status={PlayerStatus.Disconnected}
-        cards={cards}
-        stackOpenDeckCards={stackOpenDeckCards}
-      />
+    <Stack sx={{ width: '100%' }}>
+      <Opponent id="opponent-1" username="First" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
+      <Opponent id="opponent-2" username="Second" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
+      <Opponent id="opponent-3" username="Disconnected" status={PlayerStatus.Disconnected} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
     </Stack>
   ),
 }

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.stories.tsx
@@ -1,7 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { CardColors, PlayerStatus } from '@memebattle/ligretto-shared'
+import { Stack } from '@memebattle/ui'
 
 import { Opponent } from './Opponent'
+
+const cards = [
+  { color: CardColors.red, value: 5 },
+  { color: CardColors.green, value: 7 },
+  { color: CardColors.yellow, value: 9 },
+]
+
+const stackOpenDeckCards = [{ color: CardColors.blue, value: 3 }]
 
 const meta: Meta<typeof Opponent> = {
   title: 'Ligretto / Opponent',
@@ -10,12 +19,8 @@ const meta: Meta<typeof Opponent> = {
     id: 'opponent-id',
     username: 'Opponent',
     status: PlayerStatus.InGame,
-    stackOpenDeckCards: [{ color: CardColors.blue, value: 3 }],
-    cards: [
-      { color: CardColors.red, value: 5 },
-      { color: CardColors.green, value: 7 },
-      { color: CardColors.yellow, value: 9 },
-    ],
+    stackOpenDeckCards,
+    cards,
   },
 }
 
@@ -29,4 +34,26 @@ export const Disconnected: Story = {
   args: {
     status: PlayerStatus.Disconnected,
   },
+}
+
+export const MobileOpponents: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  render: () => (
+    <Stack spacing={1} sx={{ width: '100%' }}>
+      <Opponent index={0} id="opponent-1" username="First" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
+      <Opponent index={1} id="opponent-2" username="Second" status={PlayerStatus.InGame} cards={cards} stackOpenDeckCards={stackOpenDeckCards} />
+      <Opponent
+        index={2}
+        id="opponent-3"
+        username="Disconnected"
+        status={PlayerStatus.Disconnected}
+        cards={cards}
+        stackOpenDeckCards={stackOpenDeckCards}
+      />
+    </Stack>
+  ),
 }

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -16,29 +16,28 @@ export interface OpponentCardsProps {
   avatar?: string
   status: PlayerStatus
   id: UUID
-  isDisconnected?: boolean
   ref?: Ref<HTMLDivElement>
 }
 
-export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, isDisconnected = false, ref }: OpponentCardsProps) => {
+export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, ref }: OpponentCardsProps) => {
   const stackOpenDeckCard = useMemo(() => (stackOpenDeckCards.length ? stackOpenDeckCards.slice(-1)[0] : {}), [stackOpenDeckCards])
   const avatarImg = useMemo(() => (avatar ? buildCasStaticUrl(avatar) : getRandomAvatar(id)), [avatar, id])
+  const isDisconnected = status === PlayerStatus.Disconnected
 
   return (
-    <Box
-      ref={ref}
-      role="group"
-      aria-label={`${username} player`}
-      data-connection-state={isDisconnected ? 'disconnected' : 'online'}
-      sx={{
-        filter: isDisconnected ? 'grayscale(1)' : 'none',
-        opacity: isDisconnected ? 0.5 : 1,
-        transition: 'filter 150ms, opacity 150ms',
-      }}
-    >
-      <Player status={status} avatar={avatarImg} username={username} isDisconnected={isDisconnected} />
-      {status === PlayerStatus.InGame ? (
-        <Stack direction="row" spacing={0.5}>
+    <Box ref={ref} role="group" aria-label={`${username} player`} data-connection-state={isDisconnected ? 'disconnected' : 'online'}>
+      <Player status={status} avatar={avatarImg} username={username} />
+      {status === PlayerStatus.InGame || isDisconnected ? (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          data-testid="opponent-cards"
+          sx={{
+            filter: isDisconnected ? 'grayscale(1)' : 'none',
+            opacity: isDisconnected ? 0.5 : 1,
+            transition: 'filter 150ms, opacity 150ms',
+          }}
+        >
           <CardPlace size="small">
             <Card size="small" isDisabled {...stackOpenDeckCard} />
           </CardPlace>

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -16,16 +16,27 @@ export interface OpponentCardsProps {
   avatar?: string
   status: PlayerStatus
   id: UUID
+  isDisconnected?: boolean
   ref?: Ref<HTMLDivElement>
 }
 
-export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, ref }: OpponentCardsProps) => {
+export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, isDisconnected = false, ref }: OpponentCardsProps) => {
   const stackOpenDeckCard = useMemo(() => (stackOpenDeckCards.length ? stackOpenDeckCards.slice(-1)[0] : {}), [stackOpenDeckCards])
   const avatarImg = useMemo(() => (avatar ? buildCasStaticUrl(avatar) : getRandomAvatar(id)), [avatar, id])
 
   return (
-    <Box ref={ref}>
-      <Player status={status} avatar={avatarImg} username={username} />
+    <Box
+      ref={ref}
+      role="group"
+      aria-label={`${username} player`}
+      data-connection-state={isDisconnected ? 'disconnected' : 'online'}
+      sx={{
+        filter: isDisconnected ? 'grayscale(1)' : 'none',
+        opacity: isDisconnected ? 0.5 : 1,
+        transition: 'filter 150ms, opacity 150ms',
+      }}
+    >
+      <Player status={status} avatar={avatarImg} username={username} isDisconnected={isDisconnected} />
       {status === PlayerStatus.InGame ? (
         <Stack direction="row" spacing={0.5}>
           <CardPlace size="small">

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -25,7 +25,13 @@ export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, 
   const isDisconnected = status === PlayerStatus.Disconnected
 
   return (
-    <Box ref={ref} role="group" aria-label={`${username} player`} data-connection-state={isDisconnected ? 'disconnected' : 'online'}>
+    <Box
+      ref={ref}
+      role="group"
+      aria-label={`${username} player`}
+      data-connection-state={isDisconnected ? 'disconnected' : 'online'}
+      sx={{ display: { xs: 'contents', md: 'block' } }}
+    >
       <Player status={status} avatar={avatarImg} username={username} />
       {status === PlayerStatus.InGame || isDisconnected ? (
         <Stack

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type Ref } from 'react'
-import { Box, Stack } from '@memebattle/ui'
+import { styled } from '@mui/material/styles'
+import { Stack } from '@memebattle/ui'
 import type { Card as OpponentCard, UUID } from '@memebattle/ligretto-shared'
 import { PlayerStatus } from '@memebattle/ligretto-shared'
 
@@ -9,6 +10,20 @@ import { Card, CardPlace } from '#entities/card'
 import { buildCasStaticUrl } from '#shared/api/buildCasStaticUrl'
 import { getRandomAvatar } from '#shared/ui/Avatar/getRandomAvatar'
 
+// Mobile-first: avatar and cards share one row, even opponents keep the avatar
+// on the left and odd ones on the right; desktop stacks them back into a block
+const OpponentBox = styled('div', { shouldForwardProp: prop => prop !== 'index' })<{ index: number }>(({ index, theme }) => ({
+  display: 'flex',
+  flexDirection: index % 2 === 0 ? 'row' : 'row-reverse',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  width: '100%',
+  [theme.breakpoints.up('md')]: {
+    display: 'block',
+    width: 'auto',
+  },
+}))
+
 export interface OpponentCardsProps {
   stackOpenDeckCards: OpponentCard[]
   cards: (OpponentCard | null)[]
@@ -16,21 +31,23 @@ export interface OpponentCardsProps {
   avatar?: string
   status: PlayerStatus
   id: UUID
+  /** Zero-based position among opponents: on mobile even ones keep the avatar on the left, odd ones on the right */
+  index?: number
   ref?: Ref<HTMLDivElement>
 }
 
-export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, ref }: OpponentCardsProps) => {
+export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, index = 0, ref }: OpponentCardsProps) => {
   const stackOpenDeckCard = useMemo(() => (stackOpenDeckCards.length ? stackOpenDeckCards.slice(-1)[0] : {}), [stackOpenDeckCards])
   const avatarImg = useMemo(() => (avatar ? buildCasStaticUrl(avatar) : getRandomAvatar(id)), [avatar, id])
   const isDisconnected = status === PlayerStatus.Disconnected
 
   return (
-    <Box
+    <OpponentBox
       ref={ref}
       role="group"
       aria-label={`${username} player`}
       data-connection-state={isDisconnected ? 'disconnected' : 'online'}
-      sx={{ display: { xs: 'contents', md: 'block' } }}
+      index={index}
     >
       <Player status={status} avatar={avatarImg} username={username} />
       {status === PlayerStatus.InGame || isDisconnected ? (
@@ -54,6 +71,6 @@ export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, 
           ))}
         </Stack>
       ) : null}
-    </Box>
+    </OpponentBox>
   )
 }

--- a/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Opponent/Opponent.tsx
@@ -10,17 +10,24 @@ import { Card, CardPlace } from '#entities/card'
 import { buildCasStaticUrl } from '#shared/api/buildCasStaticUrl'
 import { getRandomAvatar } from '#shared/ui/Avatar/getRandomAvatar'
 
-// Mobile-first: avatar and cards share one row, even opponents keep the avatar
-// on the left and odd ones on the right; desktop stacks them back into a block
-const OpponentBox = styled('div', { shouldForwardProp: prop => prop !== 'index' })<{ index: number }>(({ index, theme }) => ({
+// Mobile-first: avatar and cards share one row; odd opponents (1st, 3rd, ...)
+// keep the avatar on the left, even ones on the right; desktop stacks them back
+// into a block. The order relies on opponents being same-tag siblings.
+const OpponentBox = styled('div')(({ theme }) => ({
   display: 'flex',
-  flexDirection: index % 2 === 0 ? 'row' : 'row-reverse',
+  flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'flex-start',
+  gap: '0.5rem',
   width: '100%',
+  marginTop: '10px',
+  '&:nth-of-type(even)': {
+    flexDirection: 'row-reverse',
+  },
   [theme.breakpoints.up('md')]: {
     display: 'block',
     width: 'auto',
+    marginTop: 0,
   },
 }))
 
@@ -31,24 +38,16 @@ export interface OpponentCardsProps {
   avatar?: string
   status: PlayerStatus
   id: UUID
-  /** Zero-based position among opponents: on mobile even ones keep the avatar on the left, odd ones on the right */
-  index?: number
   ref?: Ref<HTMLDivElement>
 }
 
-export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, index = 0, ref }: OpponentCardsProps) => {
+export const Opponent = ({ stackOpenDeckCards, cards, avatar, username, status, id, ref }: OpponentCardsProps) => {
   const stackOpenDeckCard = useMemo(() => (stackOpenDeckCards.length ? stackOpenDeckCards.slice(-1)[0] : {}), [stackOpenDeckCards])
   const avatarImg = useMemo(() => (avatar ? buildCasStaticUrl(avatar) : getRandomAvatar(id)), [avatar, id])
   const isDisconnected = status === PlayerStatus.Disconnected
 
   return (
-    <OpponentBox
-      ref={ref}
-      role="group"
-      aria-label={`${username} player`}
-      data-connection-state={isDisconnected ? 'disconnected' : 'online'}
-      index={index}
-    >
+    <OpponentBox ref={ref} role="group" aria-label={`${username} player`} data-connection-state={isDisconnected ? 'disconnected' : 'online'}>
       <Player status={status} avatar={avatarImg} username={username} />
       {status === PlayerStatus.InGame || isDisconnected ? (
         <Stack

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.stories.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.stories.tsx
@@ -37,6 +37,21 @@ export const Opponent: Story = {
       <Player isActivePlayer={false} username="DontReadyToPlay long name" status={PlayerStatus.DontReadyToPlay} />
       <Player isActivePlayer={false} username="ReadyToPlay long name" status={PlayerStatus.ReadyToPlay} />
       <Player isActivePlayer={false} username="InGame long name" status={PlayerStatus.InGame} />
+      <Player isActivePlayer={false} username="Disconnected long name" status={PlayerStatus.Disconnected} />
+    </Stack>
+  ),
+}
+
+export const MobileOpponent: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+  render: () => (
+    <Stack spacing={1}>
+      <Player isActivePlayer={false} username="InGame long name" status={PlayerStatus.InGame} />
+      <Player isActivePlayer={false} username="Disconnected long name" status={PlayerStatus.Disconnected} />
     </Stack>
   ),
 }

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -6,8 +6,7 @@ import { PlayerStatus } from '@memebattle/ligretto-shared'
 import { styled } from '@mui/material/styles'
 
 import { Avatar } from '#shared/ui/Avatar'
-
-import { useMediaQuery, useTheme } from '@memebattle/ui'
+import { tabletHeightBySize, mobileHeightBySize } from '#entities/card'
 
 const usesCompactLayout = (status: PlayerStatus): boolean => status === PlayerStatus.InGame || status === PlayerStatus.Disconnected
 
@@ -33,7 +32,7 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
   opacity: status === PlayerStatus.DontReadyToPlay ? 0.5 : 1,
   transition: 'opacity 100ms',
   justifyContent: 'end',
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     flexDirection: 'column',
     width: '3.5rem',
     maxWidth: '3.5rem',
@@ -54,7 +53,7 @@ const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, theme
   height: usesCompactLayout(status) ? '1rem' : '2rem',
   lineHeight: '1',
   color: status === PlayerStatus.Disconnected ? theme.palette.error.main : 'inherit',
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     marginLeft: '0.125rem',
     fontSize: '0.75rem',
     width: '0.75rem',
@@ -77,9 +76,14 @@ const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconn
   filter: isDisconnected ? 'grayscale(1)' : 'none',
   opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
+  // Mobile avatar is half of the small card height, so it follows the card breakpoints
+  [theme.breakpoints.down('md')]: {
+    width: `calc(${tabletHeightBySize.small} / 2)`,
+    height: `calc(${tabletHeightBySize.small} / 2)`,
+  },
   [theme.breakpoints.down('sm')]: {
-    width: '2.5rem',
-    height: '2.5rem',
+    width: `calc(${mobileHeightBySize.small} / 2)`,
+    height: `calc(${mobileHeightBySize.small} / 2)`,
   },
 }))
 
@@ -99,7 +103,7 @@ const Username = styled('span')<UsernameProps>(({ status, isActivePlayer, theme 
   filter: status === PlayerStatus.Disconnected ? 'grayscale(1)' : 'none',
   opacity: status === PlayerStatus.Disconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     fontSize: '0.625rem',
   },
 }))
@@ -119,7 +123,7 @@ const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) =>
   maxWidth: '100%',
   width: '100%',
   marginLeft: usesCompactLayout(status) && !isActivePlayer ? '0.75rem' : 0,
-  [theme.breakpoints.down('sm')]: {
+  [theme.breakpoints.down('md')]: {
     display: 'flex',
     justifyContent: 'center',
     width: '100%',
@@ -156,13 +160,6 @@ const TitlePostfixByStatus = {
 export const Player: React.FC<PlayerProps> = props => {
   const { avatar, username, status, isActivePlayer } = props
   const isDisconnected = status === PlayerStatus.Disconnected
-
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-
-  if (isMobile && isActivePlayer) {
-    return null
-  }
 
   const Icon = IconByStatus[status]
 

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -32,19 +32,30 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
   opacity: status === PlayerStatus.DontReadyToPlay ? 0.5 : 1,
   transition: 'opacity 100ms',
   justifyContent: 'end',
-  // On mobile and tablet the avatar+nickname block matches the small card height
-  [theme.breakpoints.down('md')]: {
-    flexDirection: 'column',
-    width: '3.5rem',
-    maxWidth: '3.5rem',
-    height: tabletHeightBySize.small,
-    maxHeight: tabletHeightBySize.small,
-    justifyContent: 'space-between',
-  },
-  [theme.breakpoints.down('sm')]: {
-    height: mobileHeightBySize.small,
-    maxHeight: mobileHeightBySize.small,
-  },
+  // On mobile and tablet the block matches the height of the cards next to it:
+  // small cards for opponents, large ones for the active player
+  [theme.breakpoints.down('md')]: isActivePlayer
+    ? {
+        height: tabletHeightBySize.large,
+        maxHeight: tabletHeightBySize.large,
+      }
+    : {
+        flexDirection: 'column',
+        width: '3.5rem',
+        maxWidth: '3.5rem',
+        height: tabletHeightBySize.small,
+        maxHeight: tabletHeightBySize.small,
+        justifyContent: 'space-between',
+      },
+  [theme.breakpoints.down('sm')]: isActivePlayer
+    ? {
+        height: mobileHeightBySize.large,
+        maxHeight: mobileHeightBySize.large,
+      }
+    : {
+        height: mobileHeightBySize.small,
+        maxHeight: mobileHeightBySize.small,
+      },
 }))
 
 interface StyledIconWrapperProps {
@@ -81,15 +92,20 @@ const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconn
   filter: isDisconnected ? 'grayscale(1)' : 'none',
   opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
-  // Mobile avatar is half of the small card height, so it follows the card breakpoints
-  [theme.breakpoints.down('md')]: {
-    width: `calc(${tabletHeightBySize.small} - 21px)`,
-    height: `calc(${tabletHeightBySize.small} - 21px)`,
-  },
-  [theme.breakpoints.down('sm')]: {
-    width: `calc(${mobileHeightBySize.small} - 21px)`,
-    height: `calc(${mobileHeightBySize.small} - 21px)`,
-  },
+  // Opponent mobile avatar is the card height minus the nickname plate; the
+  // active player keeps the desktop behavior (avatar fills the block)
+  ...(isActivePlayer
+    ? null
+    : {
+        [theme.breakpoints.down('md')]: {
+          width: `calc(${tabletHeightBySize.small} - 21px)`,
+          height: `calc(${tabletHeightBySize.small} - 21px)`,
+        },
+        [theme.breakpoints.down('sm')]: {
+          width: `calc(${mobileHeightBySize.small} - 21px)`,
+          height: `calc(${mobileHeightBySize.small} - 21px)`,
+        },
+      }),
 }))
 
 interface UsernameProps {
@@ -108,9 +124,13 @@ const Username = styled('span')<UsernameProps>(({ status, isActivePlayer, theme 
   filter: status === PlayerStatus.Disconnected ? 'grayscale(1)' : 'none',
   opacity: status === PlayerStatus.Disconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
-  [theme.breakpoints.down('md')]: {
-    fontSize: '0.625rem',
-  },
+  ...(isActivePlayer
+    ? null
+    : {
+        [theme.breakpoints.down('md')]: {
+          fontSize: '0.625rem',
+        },
+      }),
 }))
 
 interface BottomProps {
@@ -128,17 +148,21 @@ const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) =>
   maxWidth: '100%',
   width: '100%',
   marginLeft: usesCompactLayout(status) && !isActivePlayer ? '0.75rem' : 0,
-  [theme.breakpoints.down('md')]: {
-    display: 'flex',
-    justifyContent: 'center',
-    width: '100%',
-    maxWidth: '100%',
-    minWidth: 0,
-    height: 'auto',
-    marginLeft: 0,
-    marginTop: '0.125rem',
-    padding: '0.125rem 0.25rem',
-  },
+  ...(isActivePlayer
+    ? null
+    : {
+        [theme.breakpoints.down('md')]: {
+          display: 'flex',
+          justifyContent: 'center',
+          width: '100%',
+          maxWidth: '100%',
+          minWidth: 0,
+          height: 'auto',
+          marginLeft: 0,
+          marginTop: '0.125rem',
+          padding: '0.125rem 0.25rem',
+        },
+      }),
 }))
 
 export interface PlayerProps {

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -9,25 +9,14 @@ import { Avatar } from '#shared/ui/Avatar'
 
 import { useMediaQuery, useTheme } from '@memebattle/ui'
 
-interface CalcPlayerHeightParams {
-  status: PlayerStatus
-  isActivePlayer?: boolean
-}
+const usesCompactLayout = (status: PlayerStatus): boolean => status === PlayerStatus.InGame || status === PlayerStatus.Disconnected
 
-const hasInGameLayout = (status: PlayerStatus): boolean => status === PlayerStatus.InGame || status === PlayerStatus.Disconnected
-
-const calcPlayerHeight = ({ status, isActivePlayer }: CalcPlayerHeightParams): string => {
-  switch (true) {
-    case isActivePlayer && hasInGameLayout(status):
-      return '9rem'
-    case isActivePlayer:
-      return '12rem'
-    case !isActivePlayer && hasInGameLayout(status):
-      return '3rem'
-    case !isActivePlayer:
-      return '10rem'
+const getPlayerHeight = (status: PlayerStatus, isActivePlayer?: boolean): string => {
+  if (usesCompactLayout(status)) {
+    return isActivePlayer ? '9rem' : '3rem'
   }
-  return '10rem'
+
+  return isActivePlayer ? '12rem' : '10rem'
 }
 
 interface StyledPlayerProps {
@@ -37,54 +26,55 @@ interface StyledPlayerProps {
 
 const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer, theme }) => ({
   display: 'flex',
-  flexDirection: hasInGameLayout(status) && !isActivePlayer ? 'row' : 'column',
-  height: calcPlayerHeight({ isActivePlayer, status }),
-  [theme.breakpoints.down('sm')]: {
-    maxWidth: '1.5rem',
-    maxHeight: '1.5rem',
-  },
+  flexDirection: usesCompactLayout(status) && !isActivePlayer ? 'row' : 'column',
+  height: getPlayerHeight(status, isActivePlayer),
   width: isActivePlayer ? '12rem' : '10rem',
   alignItems: 'center',
   opacity: status === PlayerStatus.DontReadyToPlay ? 0.5 : 1,
   transition: 'opacity 100ms',
   justifyContent: 'end',
+  [theme.breakpoints.down('sm')]: {
+    flexDirection: 'row',
+    width: 'auto',
+    maxWidth: '8rem',
+    height: '1.5rem',
+    maxHeight: '1.5rem',
+    justifyContent: 'start',
+  },
 }))
 
-const StyledIconWrapper = styled('div')(() => ({
-  marginLeft: '0.5rem',
-  fontSize: '2rem',
-  width: '2rem',
-  height: '2rem',
+interface StyledIconWrapperProps {
+  status: PlayerStatus
+}
+
+const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, theme }) => ({
+  marginLeft: usesCompactLayout(status) ? '0.25rem' : '0.5rem',
+  fontSize: usesCompactLayout(status) ? '1rem' : '2rem',
+  width: usesCompactLayout(status) ? '1rem' : '2rem',
+  height: usesCompactLayout(status) ? '1rem' : '2rem',
   lineHeight: '1',
+  color: status === PlayerStatus.Disconnected ? theme.palette.error.main : 'inherit',
+  [theme.breakpoints.down('sm')]: {
+    marginLeft: '0.125rem',
+    fontSize: '0.75rem',
+    width: '0.75rem',
+    height: '0.75rem',
+  },
 }))
 
-const AvatarWrapper = styled('div')(() => ({
-  position: 'relative',
+interface DisconnectedAvatarProps {
+  isActivePlayer?: boolean
+}
+
+const DisconnectedAvatar = styled('div')<DisconnectedAvatarProps>(({ isActivePlayer }) => ({
   display: 'flex',
   height: '100%',
   maxWidth: '100%',
   aspectRatio: '1',
-}))
-
-const DisconnectedAvatar = styled('div')(() => ({
-  display: 'flex',
-  width: '100%',
-  height: '100%',
+  flexShrink: isActivePlayer ? 1 : 0,
   filter: 'grayscale(1)',
   opacity: 0.5,
   transition: 'filter 150ms, opacity 150ms',
-}))
-
-const ConnectionIconWrapper = styled('div')(({ theme }) => ({
-  position: 'absolute',
-  top: 0,
-  right: 0,
-  display: 'flex',
-  fontSize: '0.75rem',
-  padding: '0.125rem',
-  borderRadius: '50%',
-  color: theme.palette.error.main,
-  background: theme.palette.background.paper,
 }))
 
 interface UsernameProps {
@@ -92,36 +82,45 @@ interface UsernameProps {
   isActivePlayer?: boolean
 }
 
-const Username = styled('span')<UsernameProps>(({ status, isActivePlayer }) => ({
+const Username = styled('span')<UsernameProps>(({ status, isActivePlayer, theme }) => ({
   color: '#fff',
-  fontSize: hasInGameLayout(status) && !isActivePlayer ? '1rem' : '1.5rem',
+  fontSize: usesCompactLayout(status) && !isActivePlayer ? '0.75rem' : '1.5rem',
   textAlign: 'center',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   width: '100%',
   whiteSpace: 'nowrap',
+  filter: status === PlayerStatus.Disconnected ? 'grayscale(1)' : 'none',
+  opacity: status === PlayerStatus.Disconnected ? 0.5 : 1,
+  transition: 'filter 150ms, opacity 150ms',
+  [theme.breakpoints.down('sm')]: {
+    fontSize: '0.625rem',
+  },
 }))
 
 interface BottomProps {
   status: PlayerStatus
   isActivePlayer?: boolean
-  isDisconnected?: boolean
 }
 
-const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer, isDisconnected }) => ({
+const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) => ({
   borderRadius: 4,
   background: theme.palette.background.paper,
   alignItems: 'center',
   display: 'flex',
   padding: '0.5rem',
+  minWidth: 0,
   maxWidth: '100%',
   width: '100%',
-  marginLeft: hasInGameLayout(status) && !isActivePlayer ? '0.75rem' : 0,
-  filter: isDisconnected ? 'grayscale(1)' : 'none',
-  opacity: isDisconnected ? 0.5 : 1,
-  transition: 'filter 150ms, opacity 150ms',
+  marginLeft: usesCompactLayout(status) && !isActivePlayer ? '0.75rem' : 0,
   [theme.breakpoints.down('sm')]: {
-    display: 'none',
+    display: 'flex',
+    width: 'auto',
+    maxWidth: '5rem',
+    minWidth: 0,
+    height: '100%',
+    marginLeft: '0.25rem',
+    padding: '0.125rem 0.25rem',
   },
 }))
 
@@ -136,7 +135,7 @@ const IconByStatus = {
   [PlayerStatus.ReadyToPlay]: CheckCircleOutlineOutlined,
   [PlayerStatus.DontReadyToPlay]: History,
   [PlayerStatus.InGame]: null,
-  [PlayerStatus.Disconnected]: null,
+  [PlayerStatus.Disconnected]: WifiOff,
 }
 
 const TitlePostfixByStatus = {
@@ -162,24 +161,19 @@ export const Player: React.FC<PlayerProps> = props => {
   return (
     <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
       {isDisconnected ? (
-        <AvatarWrapper>
-          <DisconnectedAvatar>
-            <Avatar src={avatar} alt={username} size="auto" />
-          </DisconnectedAvatar>
-          <ConnectionIconWrapper>
-            <WifiOff fontSize="inherit" titleAccess="Connection lost" />
-          </ConnectionIconWrapper>
-        </AvatarWrapper>
+        <DisconnectedAvatar isActivePlayer={isActivePlayer}>
+          <Avatar src={avatar} alt={username} size="auto" />
+        </DisconnectedAvatar>
       ) : (
         <Avatar src={avatar} alt={username} size="auto" />
       )}
-      <Bottom isActivePlayer={isActivePlayer} status={status} isDisconnected={isDisconnected} title={`${username} (${TitlePostfixByStatus[status]})`}>
+      <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>
         <Username isActivePlayer={isActivePlayer} status={status}>
           {username}
         </Username>
         {Icon ? (
-          <StyledIconWrapper>
-            <Icon fontSize="inherit" />
+          <StyledIconWrapper status={status}>
+            <Icon fontSize="inherit" titleAccess={isDisconnected ? 'Connection lost' : undefined} />
           </StyledIconWrapper>
         ) : null}
       </Bottom>

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -45,7 +45,6 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
         maxWidth: '3.5rem',
         height: tabletHeightBySize.small,
         maxHeight: tabletHeightBySize.small,
-        justifyContent: 'space-between',
       },
   [theme.breakpoints.down('sm')]: isActivePlayer
     ? {
@@ -83,35 +82,29 @@ const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, isAct
 }))
 
 interface AvatarFrameProps {
-  isActivePlayer?: boolean
+  isRowLayout?: boolean
   isDisconnected?: boolean
 }
 
-const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconnected, theme }) => ({
+// In column layouts the avatar flexes into the space left by the nickname
+// plate; fixed content-based sizes would overflow the fixed-height block
+const avatarColumnStyles = {
+  flex: '1 1 auto',
+  minHeight: 0,
+  height: 'auto',
+}
+
+const AvatarFrame = styled('div')<AvatarFrameProps>(({ isRowLayout, isDisconnected, theme }) => ({
   display: 'flex',
   justifyContent: 'center',
-  // The active player's avatar takes the space left by the nickname plate;
-  // fixed content-based sizes would overflow the fixed-height block
-  ...(isActivePlayer ? { flex: '1 1 auto', minHeight: 0, height: 'auto' } : { height: '100%', flexShrink: 0 }),
   maxWidth: '100%',
   aspectRatio: '1',
   filter: isDisconnected ? 'grayscale(1)' : 'none',
   opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
-  // Opponent mobile avatar is the card height minus the nickname plate; the
-  // active player keeps the desktop behavior (avatar fills the block)
-  ...(isActivePlayer
-    ? null
-    : {
-        [theme.breakpoints.down('md')]: {
-          width: `calc(${tabletHeightBySize.small} - 21px)`,
-          height: `calc(${tabletHeightBySize.small} - 21px)`,
-        },
-        [theme.breakpoints.down('sm')]: {
-          width: `calc(${mobileHeightBySize.small} - 21px)`,
-          height: `calc(${mobileHeightBySize.small} - 21px)`,
-        },
-      }),
+  // The compact opponent row keeps the avatar at full row height until the
+  // mobile column layout kicks in
+  ...(isRowLayout ? { height: '100%', flexShrink: 0, [theme.breakpoints.down('md')]: avatarColumnStyles } : avatarColumnStyles),
 }))
 
 interface UsernameProps {
@@ -200,7 +193,7 @@ export const Player: React.FC<PlayerProps> = props => {
 
   return (
     <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
-      <AvatarFrame isActivePlayer={isActivePlayer} isDisconnected={isDisconnected}>
+      <AvatarFrame isRowLayout={usesCompactLayout(status) && !isActivePlayer} isDisconnected={isDisconnected}>
         <Avatar src={avatar} alt={username} size="auto" />
       </AvatarFrame>
       <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -144,14 +144,16 @@ export const Player: React.FC<PlayerProps> = props => {
 
   return (
     <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
-      <AvatarWrapper>
-        <Avatar src={avatar} alt={username} size="auto" />
-        {isDisconnected ? (
+      {isDisconnected ? (
+        <AvatarWrapper>
+          <Avatar src={avatar} alt={username} size="auto" />
           <ConnectionIconWrapper>
             <WifiOff fontSize="inherit" titleAccess="Connection lost" />
           </ConnectionIconWrapper>
-        ) : null}
-      </AvatarWrapper>
+        </AvatarWrapper>
+      ) : (
+        <Avatar src={avatar} alt={username} size="auto" />
+      )}
       <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>
         <Username isActivePlayer={isActivePlayer} status={status}>
           {username}

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import History from '@mui/icons-material/History'
 import CheckCircleOutlineOutlined from '@mui/icons-material/CheckCircleOutlineOutlined'
+import WifiOff from '@mui/icons-material/WifiOff'
 import { PlayerStatus } from '@memebattle/ligretto-shared'
 import { styled } from '@mui/material/styles'
 
@@ -55,6 +56,26 @@ const StyledIconWrapper = styled('div')(() => ({
   lineHeight: '1',
 }))
 
+const AvatarWrapper = styled('div')(() => ({
+  position: 'relative',
+  display: 'flex',
+  height: '100%',
+  maxWidth: '100%',
+  aspectRatio: '1',
+}))
+
+const ConnectionIconWrapper = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  display: 'flex',
+  fontSize: '0.75rem',
+  padding: '0.125rem',
+  borderRadius: '50%',
+  color: theme.palette.error.main,
+  background: theme.palette.background.paper,
+}))
+
 interface UsernameProps {
   status: PlayerStatus
   isActivePlayer?: boolean
@@ -94,6 +115,7 @@ export interface PlayerProps {
   avatar?: string
   status: PlayerStatus
   isActivePlayer?: boolean
+  isDisconnected?: boolean
 }
 
 const IconByStatus = {
@@ -109,7 +131,7 @@ const TitlePostfixByStatus = {
 }
 
 export const Player: React.FC<PlayerProps> = props => {
-  const { avatar, username, status, isActivePlayer } = props
+  const { avatar, username, status, isActivePlayer, isDisconnected = false } = props
 
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
@@ -122,7 +144,14 @@ export const Player: React.FC<PlayerProps> = props => {
 
   return (
     <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
-      <Avatar src={avatar} alt={username} size="auto" />
+      <AvatarWrapper>
+        <Avatar src={avatar} alt={username} size="auto" />
+        {isDisconnected ? (
+          <ConnectionIconWrapper>
+            <WifiOff fontSize="inherit" titleAccess="Connection lost" />
+          </ConnectionIconWrapper>
+        ) : null}
+      </AvatarWrapper>
       <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>
         <Username isActivePlayer={isActivePlayer} status={status}>
           {username}

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -60,21 +60,26 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
 
 interface StyledIconWrapperProps {
   status: PlayerStatus
+  isActivePlayer?: boolean
 }
 
-const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, theme }) => ({
+const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, isActivePlayer, theme }) => ({
   marginLeft: usesCompactLayout(status) ? '0.25rem' : '0.5rem',
   fontSize: usesCompactLayout(status) ? '1rem' : '2rem',
   width: usesCompactLayout(status) ? '1rem' : '2rem',
   height: usesCompactLayout(status) ? '1rem' : '2rem',
   lineHeight: '1',
   color: status === PlayerStatus.Disconnected ? theme.palette.error.main : 'inherit',
-  [theme.breakpoints.down('md')]: {
-    marginLeft: '0.125rem',
-    fontSize: '0.75rem',
-    width: '0.75rem',
-    height: '0.75rem',
-  },
+  ...(isActivePlayer
+    ? null
+    : {
+        [theme.breakpoints.down('md')]: {
+          marginLeft: '0.125rem',
+          fontSize: '0.75rem',
+          width: '0.75rem',
+          height: '0.75rem',
+        },
+      }),
 }))
 
 interface AvatarFrameProps {
@@ -85,10 +90,11 @@ interface AvatarFrameProps {
 const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconnected, theme }) => ({
   display: 'flex',
   justifyContent: 'center',
-  height: '100%',
+  // The active player's avatar takes the space left by the nickname plate;
+  // fixed content-based sizes would overflow the fixed-height block
+  ...(isActivePlayer ? { flex: '1 1 auto', minHeight: 0, height: 'auto' } : { height: '100%', flexShrink: 0 }),
   maxWidth: '100%',
   aspectRatio: '1',
-  flexShrink: isActivePlayer ? 1 : 0,
   filter: isDisconnected ? 'grayscale(1)' : 'none',
   opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
@@ -202,7 +208,7 @@ export const Player: React.FC<PlayerProps> = props => {
           {username}
         </Username>
         {Icon ? (
-          <StyledIconWrapper status={status}>
+          <StyledIconWrapper status={status} isActivePlayer={isActivePlayer}>
             <Icon fontSize="inherit" titleAccess={isDisconnected ? 'Connection lost' : undefined} />
           </StyledIconWrapper>
         ) : null}

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -64,6 +64,15 @@ const AvatarWrapper = styled('div')(() => ({
   aspectRatio: '1',
 }))
 
+const DisconnectedAvatar = styled('div')(() => ({
+  display: 'flex',
+  width: '100%',
+  height: '100%',
+  filter: 'grayscale(1)',
+  opacity: 0.5,
+  transition: 'filter 150ms, opacity 150ms',
+}))
+
 const ConnectionIconWrapper = styled('div')(({ theme }) => ({
   position: 'absolute',
   top: 0,
@@ -94,9 +103,10 @@ const Username = styled('span')<UsernameProps>(({ status, isActivePlayer }) => (
 interface BottomProps {
   status: PlayerStatus
   isActivePlayer?: boolean
+  isDisconnected?: boolean
 }
 
-const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) => ({
+const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer, isDisconnected }) => ({
   borderRadius: 4,
   background: theme.palette.background.paper,
   alignItems: 'center',
@@ -105,6 +115,9 @@ const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) =>
   maxWidth: '100%',
   width: '100%',
   marginLeft: status === PlayerStatus.InGame && !isActivePlayer ? '0.75rem' : 0,
+  filter: isDisconnected ? 'grayscale(1)' : 'none',
+  opacity: isDisconnected ? 0.5 : 1,
+  transition: 'filter 150ms, opacity 150ms',
   [theme.breakpoints.down('sm')]: {
     display: 'none',
   },
@@ -115,23 +128,26 @@ export interface PlayerProps {
   avatar?: string
   status: PlayerStatus
   isActivePlayer?: boolean
-  isDisconnected?: boolean
 }
 
 const IconByStatus = {
   [PlayerStatus.ReadyToPlay]: CheckCircleOutlineOutlined,
   [PlayerStatus.DontReadyToPlay]: History,
   [PlayerStatus.InGame]: null,
+  [PlayerStatus.Disconnected]: null,
 }
 
 const TitlePostfixByStatus = {
   [PlayerStatus.ReadyToPlay]: 'ready',
   [PlayerStatus.DontReadyToPlay]: 'not ready',
   [PlayerStatus.InGame]: 'playing',
+  [PlayerStatus.Disconnected]: 'disconnected',
 }
 
 export const Player: React.FC<PlayerProps> = props => {
-  const { avatar, username, status, isActivePlayer, isDisconnected = false } = props
+  const { avatar, username, status, isActivePlayer } = props
+  const isDisconnected = status === PlayerStatus.Disconnected
+  const layoutStatus = isDisconnected ? PlayerStatus.InGame : status
 
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
@@ -143,10 +159,12 @@ export const Player: React.FC<PlayerProps> = props => {
   const Icon = IconByStatus[status]
 
   return (
-    <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
+    <StyledPlayer status={layoutStatus} isActivePlayer={isActivePlayer}>
       {isDisconnected ? (
         <AvatarWrapper>
-          <Avatar src={avatar} alt={username} size="auto" />
+          <DisconnectedAvatar>
+            <Avatar src={avatar} alt={username} size="auto" />
+          </DisconnectedAvatar>
           <ConnectionIconWrapper>
             <WifiOff fontSize="inherit" titleAccess="Connection lost" />
           </ConnectionIconWrapper>
@@ -154,8 +172,13 @@ export const Player: React.FC<PlayerProps> = props => {
       ) : (
         <Avatar src={avatar} alt={username} size="auto" />
       )}
-      <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>
-        <Username isActivePlayer={isActivePlayer} status={status}>
+      <Bottom
+        isActivePlayer={isActivePlayer}
+        status={layoutStatus}
+        isDisconnected={isDisconnected}
+        title={`${username} (${TitlePostfixByStatus[status]})`}
+      >
+        <Username isActivePlayer={isActivePlayer} status={layoutStatus}>
           {username}
         </Username>
         {Icon ? (

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -14,13 +14,15 @@ interface CalcPlayerHeightParams {
   isActivePlayer?: boolean
 }
 
+const hasInGameLayout = (status: PlayerStatus): boolean => status === PlayerStatus.InGame || status === PlayerStatus.Disconnected
+
 const calcPlayerHeight = ({ status, isActivePlayer }: CalcPlayerHeightParams): string => {
   switch (true) {
-    case isActivePlayer && status === PlayerStatus.InGame:
+    case isActivePlayer && hasInGameLayout(status):
       return '9rem'
     case isActivePlayer:
       return '12rem'
-    case !isActivePlayer && status === PlayerStatus.InGame:
+    case !isActivePlayer && hasInGameLayout(status):
       return '3rem'
     case !isActivePlayer:
       return '10rem'
@@ -35,7 +37,7 @@ interface StyledPlayerProps {
 
 const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer, theme }) => ({
   display: 'flex',
-  flexDirection: status === PlayerStatus.InGame && !isActivePlayer ? 'row' : 'column',
+  flexDirection: hasInGameLayout(status) && !isActivePlayer ? 'row' : 'column',
   height: calcPlayerHeight({ isActivePlayer, status }),
   [theme.breakpoints.down('sm')]: {
     maxWidth: '1.5rem',
@@ -92,7 +94,7 @@ interface UsernameProps {
 
 const Username = styled('span')<UsernameProps>(({ status, isActivePlayer }) => ({
   color: '#fff',
-  fontSize: status === PlayerStatus.InGame && !isActivePlayer ? '1rem' : '1.5rem',
+  fontSize: hasInGameLayout(status) && !isActivePlayer ? '1rem' : '1.5rem',
   textAlign: 'center',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
@@ -114,7 +116,7 @@ const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer, isDi
   padding: '0.5rem',
   maxWidth: '100%',
   width: '100%',
-  marginLeft: status === PlayerStatus.InGame && !isActivePlayer ? '0.75rem' : 0,
+  marginLeft: hasInGameLayout(status) && !isActivePlayer ? '0.75rem' : 0,
   filter: isDisconnected ? 'grayscale(1)' : 'none',
   opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
@@ -147,7 +149,6 @@ const TitlePostfixByStatus = {
 export const Player: React.FC<PlayerProps> = props => {
   const { avatar, username, status, isActivePlayer } = props
   const isDisconnected = status === PlayerStatus.Disconnected
-  const layoutStatus = isDisconnected ? PlayerStatus.InGame : status
 
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
@@ -159,7 +160,7 @@ export const Player: React.FC<PlayerProps> = props => {
   const Icon = IconByStatus[status]
 
   return (
-    <StyledPlayer status={layoutStatus} isActivePlayer={isActivePlayer}>
+    <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
       {isDisconnected ? (
         <AvatarWrapper>
           <DisconnectedAvatar>
@@ -172,13 +173,8 @@ export const Player: React.FC<PlayerProps> = props => {
       ) : (
         <Avatar src={avatar} alt={username} size="auto" />
       )}
-      <Bottom
-        isActivePlayer={isActivePlayer}
-        status={layoutStatus}
-        isDisconnected={isDisconnected}
-        title={`${username} (${TitlePostfixByStatus[status]})`}
-      >
-        <Username isActivePlayer={isActivePlayer} status={layoutStatus}>
+      <Bottom isActivePlayer={isActivePlayer} status={status} isDisconnected={isDisconnected} title={`${username} (${TitlePostfixByStatus[status]})`}>
+        <Username isActivePlayer={isActivePlayer} status={status}>
           {username}
         </Username>
         {Icon ? (

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -32,13 +32,18 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
   opacity: status === PlayerStatus.DontReadyToPlay ? 0.5 : 1,
   transition: 'opacity 100ms',
   justifyContent: 'end',
+  // On mobile and tablet the avatar+nickname block matches the small card height
   [theme.breakpoints.down('md')]: {
     flexDirection: 'column',
     width: '3.5rem',
     maxWidth: '3.5rem',
-    height: 'auto',
-    maxHeight: 'none',
-    justifyContent: 'start',
+    height: tabletHeightBySize.small,
+    maxHeight: tabletHeightBySize.small,
+    justifyContent: 'center',
+  },
+  [theme.breakpoints.down('sm')]: {
+    height: mobileHeightBySize.small,
+    maxHeight: mobileHeightBySize.small,
   },
 }))
 

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -34,11 +34,11 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
   transition: 'opacity 100ms',
   justifyContent: 'end',
   [theme.breakpoints.down('sm')]: {
-    flexDirection: 'row',
-    width: 'auto',
-    maxWidth: '8rem',
-    height: '1.5rem',
-    maxHeight: '1.5rem',
+    flexDirection: 'column',
+    width: '3.5rem',
+    maxWidth: '3.5rem',
+    height: 'auto',
+    maxHeight: 'none',
     justifyContent: 'start',
   },
 }))
@@ -62,19 +62,25 @@ const StyledIconWrapper = styled('div')<StyledIconWrapperProps>(({ status, theme
   },
 }))
 
-interface DisconnectedAvatarProps {
+interface AvatarFrameProps {
   isActivePlayer?: boolean
+  isDisconnected?: boolean
 }
 
-const DisconnectedAvatar = styled('div')<DisconnectedAvatarProps>(({ isActivePlayer }) => ({
+const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconnected, theme }) => ({
   display: 'flex',
+  justifyContent: 'center',
   height: '100%',
   maxWidth: '100%',
   aspectRatio: '1',
   flexShrink: isActivePlayer ? 1 : 0,
-  filter: 'grayscale(1)',
-  opacity: 0.5,
+  filter: isDisconnected ? 'grayscale(1)' : 'none',
+  opacity: isDisconnected ? 0.5 : 1,
   transition: 'filter 150ms, opacity 150ms',
+  [theme.breakpoints.down('sm')]: {
+    width: '2.5rem',
+    height: '2.5rem',
+  },
 }))
 
 interface UsernameProps {
@@ -115,11 +121,13 @@ const Bottom = styled('div')<BottomProps>(({ theme, status, isActivePlayer }) =>
   marginLeft: usesCompactLayout(status) && !isActivePlayer ? '0.75rem' : 0,
   [theme.breakpoints.down('sm')]: {
     display: 'flex',
-    width: 'auto',
-    maxWidth: '5rem',
+    justifyContent: 'center',
+    width: '100%',
+    maxWidth: '100%',
     minWidth: 0,
-    height: '100%',
-    marginLeft: '0.25rem',
+    height: 'auto',
+    marginLeft: 0,
+    marginTop: '0.125rem',
     padding: '0.125rem 0.25rem',
   },
 }))
@@ -160,13 +168,9 @@ export const Player: React.FC<PlayerProps> = props => {
 
   return (
     <StyledPlayer status={status} isActivePlayer={isActivePlayer}>
-      {isDisconnected ? (
-        <DisconnectedAvatar isActivePlayer={isActivePlayer}>
-          <Avatar src={avatar} alt={username} size="auto" />
-        </DisconnectedAvatar>
-      ) : (
+      <AvatarFrame isActivePlayer={isActivePlayer} isDisconnected={isDisconnected}>
         <Avatar src={avatar} alt={username} size="auto" />
-      )}
+      </AvatarFrame>
       <Bottom isActivePlayer={isActivePlayer} status={status} title={`${username} (${TitlePostfixByStatus[status]})`}>
         <Username isActivePlayer={isActivePlayer} status={status}>
           {username}

--- a/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/Player/Player.tsx
@@ -39,7 +39,7 @@ const StyledPlayer = styled('div')<StyledPlayerProps>(({ status, isActivePlayer,
     maxWidth: '3.5rem',
     height: tabletHeightBySize.small,
     maxHeight: tabletHeightBySize.small,
-    justifyContent: 'center',
+    justifyContent: 'space-between',
   },
   [theme.breakpoints.down('sm')]: {
     height: mobileHeightBySize.small,
@@ -83,12 +83,12 @@ const AvatarFrame = styled('div')<AvatarFrameProps>(({ isActivePlayer, isDisconn
   transition: 'filter 150ms, opacity 150ms',
   // Mobile avatar is half of the small card height, so it follows the card breakpoints
   [theme.breakpoints.down('md')]: {
-    width: `calc(${tabletHeightBySize.small} / 2)`,
-    height: `calc(${tabletHeightBySize.small} / 2)`,
+    width: `calc(${tabletHeightBySize.small} - 21px)`,
+    height: `calc(${tabletHeightBySize.small} - 21px)`,
   },
   [theme.breakpoints.down('sm')]: {
-    width: `calc(${mobileHeightBySize.small} / 2)`,
-    height: `calc(${mobileHeightBySize.small} / 2)`,
+    width: `calc(${mobileHeightBySize.small} - 21px)`,
+    height: `calc(${mobileHeightBySize.small} - 21px)`,
   },
 }))
 

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameContainer.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameContainer.tsx
@@ -26,10 +26,9 @@ export const GameContainer = () => {
     <CardFocusProvider enabled={isDndEnabled && !isPlayerSpectator && gameStatus === GameStatus.InGame}>
       {gameStatus === GameStatus.Starting && <ScreenCountdown timeToGo={startingDelayInSec} />}
       <GameGrid centerElement={<PlaygroundContainer />} bottomElement={isPlayerSpectator ? null : <CardsPanelContainer />}>
-        {opponents.map((opponent, index) => (
+        {opponents.map(opponent => (
           <Opponent
             id={opponent.id}
-            index={index}
             avatar={opponent.avatar}
             status={opponent.status}
             username={opponent.username}

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameContainer.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameContainer.tsx
@@ -26,9 +26,10 @@ export const GameContainer = () => {
     <CardFocusProvider enabled={isDndEnabled && !isPlayerSpectator && gameStatus === GameStatus.InGame}>
       {gameStatus === GameStatus.Starting && <ScreenCountdown timeToGo={startingDelayInSec} />}
       <GameGrid centerElement={<PlaygroundContainer />} bottomElement={isPlayerSpectator ? null : <CardsPanelContainer />}>
-        {opponents.map(opponent => (
+        {opponents.map((opponent, index) => (
           <Opponent
             id={opponent.id}
+            index={index}
             avatar={opponent.avatar}
             status={opponent.status}
             username={opponent.username}

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
@@ -51,11 +51,8 @@ export const DesktopGameGrid: React.FC<React.PropsWithChildren<RoomGridProps>> =
   )
 }
 
-const MobileOpponentCardsWrapper = styled('div')<{ index: number }>(({ index }) => ({
-  display: 'flex',
-  flexDirection: index % 2 === 0 ? 'row' : 'row-reverse',
-  alignItems: 'center',
-  justifyContent: 'flex-start',
+// Avatar/cards order and side are handled by Opponent itself (based on its index)
+const MobileOpponentCardsWrapper = styled('div')(() => ({
   width: '100%',
   marginTop: '10px',
 }))
@@ -63,9 +60,7 @@ const MobileOpponentCardsWrapper = styled('div')<{ index: number }>(({ index }) 
 export const MobileGameGrid: React.FC<React.PropsWithChildren<RoomGridProps>> = ({ children, centerElement, bottomElement }) => (
   <Room>
     {React.Children.map(children, (child, index) => (
-      <MobileOpponentCardsWrapper index={index} key={index}>
-        {child}
-      </MobileOpponentCardsWrapper>
+      <MobileOpponentCardsWrapper key={index}>{child}</MobileOpponentCardsWrapper>
     ))}
     {centerElement}
     {bottomElement}

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
@@ -56,6 +56,7 @@ const MobileOpponentCardsWrapper = styled('div')<{ index: number }>(({ index }) 
   flexDirection: index % 2 === 0 ? 'row' : 'row-reverse',
   alignItems: 'center',
   justifyContent: 'flex-start',
+  width: '100%',
   marginTop: '10px',
 }))
 

--- a/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
+++ b/apps/ligretto-frontend/src/widgets/game/ui/GameGrid/GameGrid.tsx
@@ -51,17 +51,11 @@ export const DesktopGameGrid: React.FC<React.PropsWithChildren<RoomGridProps>> =
   )
 }
 
-// Avatar/cards order and side are handled by Opponent itself (based on its index)
-const MobileOpponentCardsWrapper = styled('div')(() => ({
-  width: '100%',
-  marginTop: '10px',
-}))
-
+// Opponents lay themselves out (avatar/cards order alternates via :nth-of-type),
+// so they must stay direct same-tag siblings inside Room
 export const MobileGameGrid: React.FC<React.PropsWithChildren<RoomGridProps>> = ({ children, centerElement, bottomElement }) => (
   <Room>
-    {React.Children.map(children, (child, index) => (
-      <MobileOpponentCardsWrapper key={index}>{child}</MobileOpponentCardsWrapper>
-    ))}
+    {children}
     {centerElement}
     {bottomElement}
   </Room>

--- a/packages/cas-services/dist/request.cjs
+++ b/packages/cas-services/dist/request.cjs
@@ -27,17 +27,16 @@ var __webpack_require__ = {};
 })();
 var __webpack_exports__ = {};
 __webpack_require__.r(__webpack_exports__);
-__webpack_require__.d(__webpack_exports__, {
-    createBaseRequest: ()=>createBaseRequest
-});
-const external_qs_namespaceObject = require("qs");
+const buildSearchParams = (params)=>{
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params))if (null != value) if (Array.isArray(value)) for (const item of value)searchParams.append(key, String(item));
+    else searchParams.append(key, String(value));
+    return searchParams;
+};
 const createBaseRequest = ({ casURI, errorLogger, successLogger })=>{
     const doRequest = async (method, path, body, config)=>{
         let url = `${casURI}${path}`;
-        if (config?.params) url += `?${(0, external_qs_namespaceObject.stringify)(config.params, {
-            arrayFormat: 'repeat',
-            indices: false
-        })}`;
+        if (config?.params) url += `?${buildSearchParams(config.params)}`;
         const headers = {
             ...config?.headers
         };
@@ -75,6 +74,9 @@ const createBaseRequest = ({ casURI, errorLogger, successLogger })=>{
         patch: (url, data, config)=>doRequest('PATCH', url, data, config)
     };
 };
+__webpack_require__.d(__webpack_exports__, {}, {
+    createBaseRequest: createBaseRequest
+});
 exports.createBaseRequest = __webpack_exports__.createBaseRequest;
 for(var __rspack_i in __webpack_exports__)if (-1 === [
     "createBaseRequest"

--- a/packages/cas-services/dist/request.js
+++ b/packages/cas-services/dist/request.js
@@ -1,11 +1,13 @@
-import { stringify } from "qs";
+const buildSearchParams = (params)=>{
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params))if (null != value) if (Array.isArray(value)) for (const item of value)searchParams.append(key, String(item));
+    else searchParams.append(key, String(value));
+    return searchParams;
+};
 const createBaseRequest = ({ casURI, errorLogger, successLogger })=>{
     const doRequest = async (method, path, body, config)=>{
         let url = `${casURI}${path}`;
-        if (config?.params) url += `?${stringify(config.params, {
-            arrayFormat: 'repeat',
-            indices: false
-        })}`;
+        if (config?.params) url += `?${buildSearchParams(config.params)}`;
         const headers = {
             ...config?.headers
         };

--- a/packages/cas-services/package.json
+++ b/packages/cas-services/package.json
@@ -26,14 +26,12 @@
     "ts-check": "tsc --noEmit"
   },
   "dependencies": {
-    "jsonwebtoken": "catalog:",
-    "qs": "catalog:"
+    "jsonwebtoken": "catalog:"
   },
   "devDependencies": {
     "@rslib/core": "catalog:",
     "@types/jsonwebtoken": "catalog:",
     "@types/node": "24.9.2",
-    "@types/qs": "catalog:",
     "chalk": "catalog:",
     "chalk-animation": "catalog:",
     "dotenv-extended": "catalog:",

--- a/packages/cas-services/src/request.ts
+++ b/packages/cas-services/src/request.ts
@@ -1,5 +1,22 @@
-import { stringify } from 'qs'
 import type { ErrorLoggerFunction, SuccessLoggerFunction } from './types'
+
+// Flat params only (strings, numbers, arrays); arrays are repeated: ids=a&ids=b
+const buildSearchParams = (params: Record<string, unknown>): URLSearchParams => {
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item))
+      }
+    } else {
+      searchParams.append(key, String(value))
+    }
+  }
+  return searchParams
+}
 
 type RequestConfig = {
   headers?: Record<string, string>
@@ -24,7 +41,7 @@ export const createBaseRequest = ({
   const doRequest = async <T>(method: string, path: string, body?: unknown, config?: RequestConfig): Promise<T> => {
     let url = `${casURI}${path}`
     if (config?.params) {
-      url += `?${stringify(config.params, { arrayFormat: 'repeat', indices: false })}`
+      url += `?${buildSearchParams(config.params)}`
     }
 
     const headers: Record<string, string> = { ...config?.headers }

--- a/packages/ligretto-shared/src/types.ts
+++ b/packages/ligretto-shared/src/types.ts
@@ -62,6 +62,7 @@ export enum PlayerStatus {
   DontReadyToPlay = 'DontReadyToPlay',
   ReadyToPlay = 'ReadyToPlay',
   InGame = 'InGame',
+  Disconnected = 'Disconnected',
 }
 
 export interface Game {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ catalogs:
     '@types/negotiator':
       specifier: ^0
       version: 0.6.4
-    '@types/qs':
-      specifier: ^6.15.1
-      version: 6.15.1
     '@vinejs/vine':
       specifier: 4.4.0
       version: 4.4.0
@@ -257,9 +254,6 @@ catalogs:
     proxy-addr:
       specifier: ^2.0.6
       version: 2.0.7
-    qs:
-      specifier: ^6.15.3
-      version: 6.15.3
     react:
       specifier: ^19.2.8
       version: 19.2.8
@@ -434,7 +428,7 @@ importers:
     dependencies:
       '@memebattle/cas-services':
         specifier: workspace:^
-        version: file:packages/cas-services
+        version: link:../../packages/cas-services
       '@memebattle/ui':
         specifier: workspace:^
         version: link:../../packages/ui
@@ -668,7 +662,7 @@ importers:
         version: 3.3.5
       '@memebattle/cas-services':
         specifier: workspace:^
-        version: file:packages/cas-services
+        version: link:../../packages/cas-services
       '@memebattle/ligretto-shared':
         specifier: workspace:^
         version: link:../../packages/ligretto-shared
@@ -753,7 +747,7 @@ importers:
         version: file:apps/auth-front(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@memebattle/ui@file:packages/ui(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(lodash@4.18.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@memebattle/cas-services':
         specifier: workspace:^
-        version: file:packages/cas-services
+        version: link:../../packages/cas-services
       '@memebattle/ligretto-shared':
         specifier: workspace:^
         version: link:../../packages/ligretto-shared
@@ -871,7 +865,7 @@ importers:
         version: 3.3.5
       '@memebattle/cas-services':
         specifier: workspace:^
-        version: file:packages/cas-services
+        version: link:../../packages/cas-services
       '@memebattle/ligretto-shared':
         specifier: workspace:^
         version: link:../../packages/ligretto-shared
@@ -937,9 +931,6 @@ importers:
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
-      qs:
-        specifier: 'catalog:'
-        version: 6.15.3
     devDependencies:
       '@rslib/core':
         specifier: 'catalog:'
@@ -950,9 +941,6 @@ importers:
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
-      '@types/qs':
-        specifier: 'catalog:'
-        version: 6.15.1
       chalk:
         specifier: 'catalog:'
         version: 6.0.0
@@ -4359,9 +4347,6 @@ packages:
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -10366,7 +10351,6 @@ snapshots:
   '@memebattle/cas-services@file:packages/cas-services':
     dependencies:
       jsonwebtoken: 9.0.3
-      qs: 6.15.1
 
   '@memebattle/ui@file:packages/ui(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(react@19.2.8)(supports-color@10.2.2))(@types/react@19.2.17)(lodash@4.18.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -12015,8 +11999,6 @@ snapshots:
   '@types/pluralize@0.0.33': {}
 
   '@types/prop-types@15.7.15': {}
-
-  '@types/qs@6.15.1': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -15796,6 +15778,7 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+    optional: true
 
   query-string@8.1.0:
     dependencies:
@@ -16421,6 +16404,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
+    optional: true
 
   side-channel-map@1.0.1:
     dependencies:
@@ -16452,6 +16436,7 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+    optional: true
 
   siginfo@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,7 +84,6 @@ catalog:
   '@types/mdx': ^2.0.14
   '@types/negotiator': ^0
   '@types/node': 24.13.3
-  '@types/qs': ^6.15.1
   '@types/react': ^19.2.17
   '@types/react-dom': ^19.2.3
   '@vinejs/vine': 4.4.0
@@ -125,7 +124,6 @@ catalog:
   postcss: ^8.5.23
   prom-client: ^15.1.3
   proxy-addr: ^2.0.6
-  qs: ^6.15.3
   react: ^19.2.8
   react-dom: ^19.2.8
   react-dropzone: 19.1.1


### PR DESCRIPTION
## Summary

- add a presentational `isDisconnected` state for Ligretto opponents
- dim/grayscale the complete opponent area, including the player and all visible cards
- show an accessible connection-loss indicator over the player avatar
- add deterministic connected and disconnected Storybook stories
- add a regression test for disconnected → connected rendering and avatar/icon layout

## Scope

This PR implements the visual contract only. Connection-state propagation and reconnect orchestration remain in the parent feature #644.

## Testing

- `pnpm --filter @memebattle/ligretto-frontend test:ci` — 7 files, 54 tests passed
- `pnpm lint:check` — passed
- `pnpm fmt:check` — passed
- `pnpm ts-check` — passed from a clean generated-artifact state
- `pnpm test:ci` — passed across the monorepo before the final CSS-only avatar sizing adjustment; the Ligretto suite was rerun after that adjustment
- `pnpm build-storybook --quiet` — passed
- Playwright screenshot of `Ligretto / Opponent / Disconnected` — visually verified avatar, connection icon, username, and all card positions
- regression sabotage: removing the grayscale behavior makes the new test fail

Fixes #642
