### PR TITLE
refactor(ligretto): make in-memory storage synchronous

### DIFF
--- a/apps/ligretto-gameplay-backend/src/controllers/__tests__/gameplay-controller.spec.ts
+++ b/apps/ligretto-gameplay-backend/src/controllers/__tests__/gameplay-controller.spec.ts
@@ -80,19 +80,6 @@ describe('Gameplay Controller', () => {
     expect(socket.emit).toHaveBeenCalledWith('event', updateGameAction(expectedGame))
   })
 
-  it('broadcasts the freshest canonical game after resuming', async () => {
-    const handling = gameplayController.handleMessage(socket, resumeGameEmitAction({ gameId: pausedGame.id }) as AnyAction)
-
-    await Promise.resolve()
-    const freshestGame = await database.set(storage => {
-      const game = storage.games[pausedGame.id]
-      return (storage.games[pausedGame.id] = { ...game, name: 'Concurrently updated game' })
-    })
-    await handling
-
-    expect(socket.emit).toHaveBeenCalledWith('event', updateGameAction(freshestGame))
-  })
-
   it('does not allow a non-host socket to resume a paused game', async () => {
     const nonHostSocket = createSocketMockImpl({ data: { user: { id: 'spectator' } } })
 
@@ -102,27 +89,6 @@ describe('Gameplay Controller', () => {
     expect(game).toEqual(pausedGame)
     expect(nonHostSocket.to).not.toHaveBeenCalled()
     expect(nonHostSocket.emit).not.toHaveBeenCalled()
-  })
-
-  it('does not allow a stale former host to resume or broadcast', async () => {
-    const handling = gameplayController.handleMessage(socket, resumeGameEmitAction({ gameId: pausedGame.id }) as AnyAction)
-
-    await database.set(storage => {
-      const game = storage.games[pausedGame.id]
-      storage.games[pausedGame.id] = {
-        ...game,
-        players: {
-          ...game.players,
-          player: { ...game.players.player!, isHost: false },
-        },
-      }
-    })
-    await handling
-
-    const game = await database.get(storage => storage.games[pausedGame.id])
-    expect(game.status).toBe(GameStatus.Pause)
-    expect(socket.to).not.toHaveBeenCalled()
-    expect(socket.emit).not.toHaveBeenCalled()
   })
 
   it('ignores a resume action for an unknown game', async () => {

--- a/apps/ligretto-gameplay-backend/src/controllers/gameplay-controller.ts
+++ b/apps/ligretto-gameplay-backend/src/controllers/gameplay-controller.ts
@@ -34,31 +34,32 @@ export class GameplayController extends Controller {
   private async startGame(socket: Socket, action: ReturnType<typeof startGameEmitAction>) {
     const gameId = action.payload.gameId
 
-    const game = await this.gameService.initiateStartGame(gameId)
-    await this.updateGame(socket, gameId)
+    const game = this.gameService.initiateStartGame(gameId)
+    this.updateGame(socket, gameId)
 
-    await Promise.all([this.gameplay.startGame(gameId), wait(game.config.startingDelayInSec * 1000)])
-    await this.updateGame(socket, gameId)
+    this.gameplay.startGame(gameId)
+    await wait(game.config.startingDelayInSec * 1000)
+    this.updateGame(socket, gameId)
   }
 
-  private async resumeGame(socket: Socket, action: ReturnType<typeof resumeGameEmitAction>) {
+  private resumeGame(socket: Socket, action: ReturnType<typeof resumeGameEmitAction>) {
     const gameId = action.payload.gameId
-    const game = await this.gameService.getGame(gameId)
+    const game = this.gameService.getGame(gameId)
 
     if (!game || !game.players[socket.data.user.id]?.isHost) {
       return
     }
 
-    const resumedGame = await this.gameService.resumeGame(gameId, socket.data.user.id)
+    const resumedGame = this.gameService.resumeGame(gameId, socket.data.user.id)
     if (!resumedGame) {
       return
     }
 
-    await this.updateGame(socket, gameId)
+    this.updateGame(socket, gameId)
   }
 
-  private async updateGame(socket: Socket, gameId: string, gameState?: Game) {
-    const game = gameState || (await this.gameService.getGame(gameId))
+  private updateGame(socket: Socket, gameId: string, gameState?: Game) {
+    const game = gameState || this.gameService.getGame(gameId)
 
     const action = updateGameAction(game)
 
@@ -66,11 +67,11 @@ export class GameplayController extends Controller {
     socket.emit('event', action)
   }
 
-  private async putCard(socket: Socket, action: ReturnType<typeof putCardAction>) {
+  private putCard(socket: Socket, action: ReturnType<typeof putCardAction>) {
     const { gameId, cardIndex, playgroundDeckIndex } = action.payload
 
-    await this.gameplay.playerPutCard(gameId, socket.data.user.id, cardIndex, playgroundDeckIndex)
-    await this.updateGame(socket, gameId)
+    this.gameplay.playerPutCard(gameId, socket.data.user.id, cardIndex, playgroundDeckIndex)
+    this.updateGame(socket, gameId)
   }
 
   private async takeCardFromLigrettoDeck(socket: Socket, action: ReturnType<typeof takeFromLigrettoDeckAction>) {
@@ -78,7 +79,7 @@ export class GameplayController extends Controller {
 
     const { game, gameResults } = await this.gameplay.playerTakeFromLigrettoDeck(gameId, socket.data.user.id)
 
-    await this.updateGame(socket, gameId, game)
+    this.updateGame(socket, gameId, game)
 
     console.log('gameResults', gameResults)
     if (gameResults) {
@@ -88,18 +89,18 @@ export class GameplayController extends Controller {
     }
   }
 
-  private async takeCardFromStackDeck(socket: Socket, action: ReturnType<typeof takeFromStackDeckAction>) {
+  private takeCardFromStackDeck(socket: Socket, action: ReturnType<typeof takeFromStackDeckAction>) {
     const { gameId } = action.payload
 
     console.log('takeCardFromStackDeck', action)
-    await this.gameplay.playerTakeFromStackDeck(gameId, socket.data.user.id)
-    await this.updateGame(socket, gameId)
+    this.gameplay.playerTakeFromStackDeck(gameId, socket.data.user.id)
+    this.updateGame(socket, gameId)
   }
 
-  private async putCardFromStackOpenDeck(socket: Socket, action: ReturnType<typeof putCardFromStackOpenDeck>) {
+  private putCardFromStackOpenDeck(socket: Socket, action: ReturnType<typeof putCardFromStackOpenDeck>) {
     const { gameId, playgroundDeckIndex } = action.payload
     console.log('putCardFromStackOpenDeck', action)
-    await this.gameplay.playerPutFromStackOpenDeck(gameId, socket.data.user.id, playgroundDeckIndex)
-    await this.updateGame(socket, gameId)
+    this.gameplay.playerPutFromStackOpenDeck(gameId, socket.data.user.id, playgroundDeckIndex)
+    this.updateGame(socket, gameId)
   }
 }

--- a/apps/ligretto-gameplay-backend/src/controllers/games-controller.ts
+++ b/apps/ligretto-gameplay-backend/src/controllers/games-controller.ts
@@ -49,9 +49,9 @@ export class GamesController extends Controller {
     socket.to(SOCKET_ROOM_LOBBY).emit('event', updateRoomsAction({ rooms: [gameToRoom(newGame)] }))
   }
 
-  private async getRooms(socket: Socket) {
+  private getRooms(socket: Socket) {
     socket.join(SOCKET_ROOM_LOBBY)
-    const games = await this.gameService.getGames()
+    const games = this.gameService.getGames()
     socket.emit('event', updateRoomsAction({ rooms: games.map(gameToRoom) }))
   }
 
@@ -63,10 +63,10 @@ export class GamesController extends Controller {
    *
    * read more: https://miro.com/app/board/o9J_l6Vx4-Q=/?moveToWidget=3458764530187757883&cot=14
    */
-  private async joinGame(socket: Socket, action: ReturnType<typeof connectToRoomEmitAction>) {
+  private joinGame(socket: Socket, action: ReturnType<typeof connectToRoomEmitAction>) {
     const roomUuid = action.payload.roomUuid
 
-    const game: Game | undefined = await this.gameService.getGame(roomUuid)
+    const game: Game | undefined = this.gameService.getGame(roomUuid)
 
     if (!game) {
       socket.emit('event', connectToRoomErrorAction())
@@ -88,14 +88,14 @@ export class GamesController extends Controller {
       return
     }
 
-    await this.userService.joinGame({ userId, gameId: game.id })
+    this.userService.joinGame({ userId, gameId: game.id })
 
     const isGameFull = Object.keys(game.players).length >= game.config.playersMaxCount
 
     const { game: updatedGame } =
       isGameFull || game.status === GameStatus.InGame
-        ? await this.gameService.addSpectator(roomUuid, { id: userId })
-        : await this.gameService.addPlayer(roomUuid, { id: userId })
+        ? this.gameService.addSpectator(roomUuid, { id: userId })
+        : this.gameService.addPlayer(roomUuid, { id: userId })
 
     socket.to(SOCKET_ROOM_LOBBY).emit('event', updateRoomsAction({ rooms: [gameToRoom(updatedGame)] }))
     socket.to(roomUuid).emit('event', updateGameAction(updatedGame))
@@ -104,10 +104,10 @@ export class GamesController extends Controller {
     socket.emit('event', updateGameAction(updatedGame))
   }
 
-  private async setPlayerStatus(socket: Socket, { payload }: ReturnType<typeof setPlayerStatusEmitAction>) {
+  private setPlayerStatus(socket: Socket, { payload }: ReturnType<typeof setPlayerStatusEmitAction>) {
     const { gameId, status } = payload
 
-    const game = await this.gameService.updateGamePlayer(gameId, socket.data.user.id, { status })
+    const game = this.gameService.updateGamePlayer(gameId, socket.data.user.id, { status })
 
     socket.to(gameId).emit('event', updateGameAction(game))
     socket.emit('event', updateGameAction(game))
@@ -118,8 +118,8 @@ export class GamesController extends Controller {
    *
    * read more: https://miro.com/app/board/o9J_l6Vx4-Q=/?moveToWidget=3458764530187757883&cot=14
    */
-  private async leaveFromRoomHandler(socket: Socket) {
-    const user = await this.userService.getUser(socket.data.user.id)
+  private leaveFromRoomHandler(socket: Socket) {
+    const user = this.userService.getUser(socket.data.user.id)
 
     if (!user || !user.currentGameId) {
       return
@@ -130,10 +130,10 @@ export class GamesController extends Controller {
       return
     }
 
-    if (!(await this.gameService.getGame(user.currentGameId))) {
+    if (!this.gameService.getGame(user.currentGameId)) {
       return
     }
-    const game = await this.gameService.leaveGame(user.currentGameId, user.id)
+    const game = this.gameService.leaveGame(user.currentGameId, user.id)
 
     if (game) {
       socket.to(game.id).emit('event', updateGameAction(game))

--- a/apps/ligretto-gameplay-backend/src/database/database.ts
+++ b/apps/ligretto-gameplay-backend/src/database/database.ts
@@ -1,36 +1,12 @@
 import { injectable } from 'inversify'
 import type { Storage } from './storage'
 
-export const storage: Storage = {
-  games: {},
-  users: {},
-}
-
 type Accessor<T> = (storage: Storage) => T
 type Setter<T = void> = (storage: Storage) => T
 
 export interface Database {
-  get<T>(accessor: Accessor<T>): Promise<T>
-  set<T>(setter: Setter<T>): Promise<T>
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  addUpdateListener(key: string, getter: (storage: Storage) => object, callback: (changes: object | undefined) => void): void
-  removeUpdateListener(key: string): void
-}
-
-// eslint-disable-next-line @typescript-eslint/ban-types
-const createChangesWatcher = <T extends object>(obj: T) => {
-  let oldValue = JSON.stringify(obj)
-
-  return (obj: T) => {
-    const value = JSON.stringify(obj)
-    if (oldValue !== value) {
-      oldValue = value
-
-      return obj
-    }
-
-    return undefined
-  }
+  get<T>(accessor: Accessor<T>): T
+  set<T>(setter: Setter<T>): T
 }
 
 @injectable()
@@ -40,43 +16,11 @@ export class Database implements Database {
     users: {},
   }
 
-  private listeners: Record<string, (nextStorage: Storage) => void> = {}
-
-  private notifyListeners() {
-    for (const listenerKey in this.listeners) {
-      if (this.listeners.hasOwnProperty(listenerKey)) {
-        const listener = this.listeners[listenerKey]
-        listener(this.storage)
-      }
-    }
+  public get<T>(accessor: Accessor<T>): T {
+    return accessor(this.storage)
   }
 
-  public get<T>(accessor: Accessor<T>) {
-    return Promise.resolve(accessor(this.storage))
-  }
-
-  public set<S>(setter: Setter<S>): Promise<S> {
-    return Promise.resolve(setter(this.storage)).then(result => {
-      this.notifyListeners()
-      return result
-    })
-  }
-
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  public addUpdateListener(key: string, getter: (storage: Storage) => object, callback: (changes: object | undefined) => void) {
-    const watched = getter(this.storage)
-    const getChanges = createChangesWatcher(watched)
-
-    this.listeners[key] = (nextStorage: Storage) => {
-      const changes = getChanges(getter(nextStorage))
-
-      if (changes) {
-        callback(changes)
-      }
-    }
-  }
-
-  public removeUpdateListener(key: string) {
-    delete this.listeners[key]
+  public set<S>(setter: Setter<S>): S {
+    return setter(this.storage)
   }
 }

--- a/apps/ligretto-gameplay-backend/src/entities/game/game.repo.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/game/game.repo.ts
@@ -8,7 +8,7 @@ import { IOC_TYPES } from '../../IOC_TYPES'
 export class GameRepository {
   @inject(IOC_TYPES.Database) private database: Database
 
-  async addGame(gameId: UUID, game: Game) {
+  addGame(gameId: UUID, game: Game) {
     return this.database.set<Game>(storage => (storage.games[gameId] = game))
   }
 
@@ -16,9 +16,9 @@ export class GameRepository {
     return this.database.get(storage => storage.games[gameId])
   }
 
-  updateGame(gameId: UUID, updater: (game: Game) => Game): Promise<Game>
-  updateGame(gameId: UUID, updater: (game: Game) => Game | undefined): Promise<Game | undefined>
-  async updateGame(gameId: UUID, updater: (game: Game) => Game | undefined): Promise<Game | undefined> {
+  updateGame(gameId: UUID, updater: (game: Game) => Game): Game
+  updateGame(gameId: UUID, updater: (game: Game) => Game | undefined): Game | undefined
+  updateGame(gameId: UUID, updater: (game: Game) => Game | undefined): Game | undefined {
     return this.database.set(storage => {
       const game = storage.games[gameId]
       if (!game) {
@@ -34,8 +34,8 @@ export class GameRepository {
     })
   }
 
-  async getGameByName(gameName: string) {
-    const games = await this.database.get(storage => storage.games)
+  getGameByName(gameName: string) {
+    const games = this.database.get(storage => storage.games)
     const gamesByNames = this.getGamesByNames(games)
     return gamesByNames[gameName]
   }
@@ -44,9 +44,8 @@ export class GameRepository {
     return this.database.set(storage => delete storage.games[gameId])
   }
 
-  async getGames(): Promise<Game[]> {
-    const games = (await this.database.get(storage => Object.values(storage.games))).filter(Boolean) as Game[]
-    return games
+  getGames(): Game[] {
+    return this.database.get(storage => Object.values(storage.games)).filter(Boolean) as Game[]
   }
 
   getGamesByNames(games: Record<UUID, Game>): Record<string, UUID | undefined> {

--- a/apps/ligretto-gameplay-backend/src/entities/game/game.service.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/game/game.service.ts
@@ -27,13 +27,17 @@ export class GameService {
   @inject(IOC_TYPES.LigrettoCoreService) private ligrettoCoreService: LigrettoCoreService
 
   async createGame(name: string, config: Partial<Game['config']> = {}): Promise<Game | null> {
-    const isGameExists = !!(await this.gameRepository.getGameByName(name))
-
-    if (isGameExists) {
+    if (this.gameRepository.getGameByName(name)) {
       return null
     }
 
     const game = await this.ligrettoCoreService.createGameService()
+
+    // Re-check after the HTTP call: a concurrent createGame with the same name
+    // may have finished while we were waiting for the core backend.
+    if (this.gameRepository.getGameByName(name)) {
+      return null
+    }
 
     return this.gameRepository.addGame(game.id, merge({}, emptyGame, { ...game, name, config: { ...emptyGame.config, ...config } }))
   }
@@ -99,10 +103,10 @@ export class GameService {
     })
   }
 
-  async addPlayer(gameId: UUID, playerData: Partial<Player> & { id: Player['id'] }) {
-    const player = await this.gameRepository.createPlayer({ ...playerData })
+  addPlayer(gameId: UUID, playerData: Partial<Player> & { id: Player['id'] }) {
+    const player = this.gameRepository.createPlayer({ ...playerData })
     return {
-      game: await this.gameRepository.updateGame(gameId, game => ({
+      game: this.gameRepository.updateGame(gameId, game => ({
         ...game,
         players: {
           ...game.players,
@@ -113,10 +117,10 @@ export class GameService {
     }
   }
 
-  async addSpectator(gameId: UUID, spectatorData: Partial<Spectator> & { id: Spectator['id'] }) {
-    const spectator = await this.gameRepository.createSpectator(spectatorData)
+  addSpectator(gameId: UUID, spectatorData: Partial<Spectator> & { id: Spectator['id'] }) {
+    const spectator = this.gameRepository.createSpectator(spectatorData)
     return {
-      game: await this.gameRepository.updateGame(gameId, game => ({
+      game: this.gameRepository.updateGame(gameId, game => ({
         ...game,
         spectators: {
           ...game.spectators,
@@ -127,8 +131,8 @@ export class GameService {
     }
   }
 
-  async updateGamePlayer(gameId: Game['id'], playerId: Player['id'], playerData: Partial<Player>) {
-    const game = await this.gameRepository.getGame(gameId)
+  updateGamePlayer(gameId: Game['id'], playerId: Player['id'], playerData: Partial<Player>) {
+    const game = this.gameRepository.getGame(gameId)
     if (!game) {
       throw Error('Game not found')
     }
@@ -154,8 +158,8 @@ export class GameService {
     return this.gameRepository.getGame(gameId)
   }
 
-  async getRoundResult(gameId: UUID) {
-    const game = await this.getGame(gameId)
+  getRoundResult(gameId: UUID) {
+    const game = this.getGame(gameId)
 
     const initialScoresByPlayer = Object.keys(game.players).reduce<Record<string, 0>>((scores, playerId) => ({ ...scores, [playerId]: 0 }), {})
 
@@ -182,22 +186,36 @@ export class GameService {
 
   async endGame(gameId: UUID) {
     const { game, gameResults } = await this.finishRound(gameId)
-    await this.gameRepository.removeGame(gameId)
+    this.gameRepository.removeGame(gameId)
 
     return [game, gameResults]
   }
 
   async finishRound(gameId: UUID): Promise<{ game?: Game; gameResults?: GameResults }> {
-    const results = await this.getRoundResult(gameId)
+    // Atomically claim the round finish: the status transition and the results
+    // snapshot happen synchronously, so concurrent callers bail out here and
+    // the round cannot be saved twice.
+    let previousStatus: GameStatus | undefined
+    const claimed = this.gameRepository.updateGame(gameId, game => {
+      if (game.status === GameStatus.RoundFinished) {
+        return undefined
+      }
+      previousStatus = game.status
+      return { ...game, status: GameStatus.RoundFinished }
+    })
+    if (!claimed) {
+      return {}
+    }
+
+    const results = this.getRoundResult(gameId)
 
     try {
       const { gameResults } = await this.ligrettoCoreService.saveGameRoundService(gameId, {
         results,
       })
 
-      const game = await this.gameRepository.updateGame(gameId, game => ({
+      const game = this.gameRepository.updateGame(gameId, game => ({
         ...game,
-        status: GameStatus.RoundFinished,
         players: Object.values(game.players).reduce(
           (players, player) => (player ? { ...players, [player.id]: { ...player, status: PlayerStatus.DontReadyToPlay } } : players),
           {},
@@ -207,6 +225,8 @@ export class GameService {
       return { game, gameResults }
     } catch (e) {
       console.error(e)
+      // Release the claim so the round can be finished again after a failed save.
+      this.gameRepository.updateGame(gameId, game => ({ ...game, status: previousStatus ?? game.status }))
       throw e
     }
   }
@@ -215,8 +235,8 @@ export class GameService {
     return this.gameRepository.getGames()
   }
 
-  async leaveGame(gameId: UUID, userId: Player['id'] | Spectator['id']): Promise<Game | undefined> {
-    let game = await this.gameRepository.updateGame(gameId, game => {
+  leaveGame(gameId: UUID, userId: Player['id'] | Spectator['id']): Game | undefined {
+    let game = this.gameRepository.updateGame(gameId, game => {
       const isHostLeaving = game.players[userId]?.isHost
 
       const players = omit(game.players, userId)
@@ -243,12 +263,12 @@ export class GameService {
 
     const playersCount = Object.keys(game.players).length
     if (playersCount === 0) {
-      await this.gameRepository.removeGame(gameId)
+      this.gameRepository.removeGame(gameId)
       return
     }
 
     if (playersCount === 1) {
-      game = await this.pauseGame(gameId)
+      game = this.pauseGame(gameId)
     }
 
     return game

--- a/apps/ligretto-gameplay-backend/src/entities/player/player.repo.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/player/player.repo.ts
@@ -7,50 +7,50 @@ import { IOC_TYPES } from '../../IOC_TYPES'
 export class PlayerRepository {
   @inject(IOC_TYPES.Database) private database: Database
 
-  async getPlayer(gameId: UUID, playerId: UUID) {
+  getPlayer(gameId: UUID, playerId: UUID) {
     return this.database.get(storage => storage.games[gameId].players[playerId])
   }
 
-  async getCards(gameId: UUID, playerId: UUID) {
+  getCards(gameId: UUID, playerId: UUID) {
     return this.database.get(storage => storage.games[gameId].players[playerId]?.cards)
   }
 
-  async getCard(gameId: UUID, playerId: UUID, position: number) {
+  getCard(gameId: UUID, playerId: UUID, position: number) {
     return this.database.get(storage => storage.games[gameId].players[playerId]?.cards[position])
   }
 
-  async addCard(gameId: UUID, playerId: UUID, card: Card, position: number) {
+  addCard(gameId: UUID, playerId: UUID, card: Card, position: number) {
     return this.database.set(storage => storage.games[gameId].players[playerId]?.cards.splice(position, 1, card))
   }
 
-  async removeCard(gameId: UUID, playerId: UUID, position: number) {
+  removeCard(gameId: UUID, playerId: UUID, position: number) {
     return this.database.set(storage => storage.games[gameId].players[playerId]?.cards.splice(position, 1, null))
   }
 
-  async getLigrettoDeck(gameId: UUID, playerId: UUID) {
+  getLigrettoDeck(gameId: UUID, playerId: UUID) {
     return this.database.get(storage => storage.games[gameId].players[playerId]?.ligrettoDeck)
   }
 
-  async removeCardFromLigrettoDeck(gameId: UUID, playerId: UUID) {
-    await this.database.set(storage => storage.games[gameId].players[playerId]?.ligrettoDeck.cards.pop())
+  removeCardFromLigrettoDeck(gameId: UUID, playerId: UUID) {
+    this.database.set(storage => storage.games[gameId].players[playerId]?.ligrettoDeck.cards.pop())
 
-    return (await this.getLigrettoDeck(gameId, playerId))?.cards.length
+    return this.getLigrettoDeck(gameId, playerId)?.cards.length
   }
 
-  async getStackDeck(gameId: UUID, playerId: UUID) {
+  getStackDeck(gameId: UUID, playerId: UUID) {
     return this.database.get(storage => storage.games[gameId].players[playerId]?.stackDeck)
   }
 
-  async getStackOpenDeck(gameId: UUID, playerId: UUID) {
+  getStackOpenDeck(gameId: UUID, playerId: UUID) {
     return this.database.get(storage => storage.games[gameId].players[playerId]?.stackOpenDeck)
   }
 
-  async removeCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
+  removeCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
     return this.database.set(storage => storage.games[gameId].players[playerId]?.stackOpenDeck.cards.pop())
   }
 
-  async updateStackDeck(gameId: UUID, playerId: UUID, updater: (cardsDeck: CardsDeck) => CardsDeck) {
-    const deck = await this.getStackDeck(gameId, playerId)
+  updateStackDeck(gameId: UUID, playerId: UUID, updater: (cardsDeck: CardsDeck) => CardsDeck) {
+    const deck = this.getStackDeck(gameId, playerId)
     if (!deck) {
       return
     }
@@ -63,8 +63,8 @@ export class PlayerRepository {
     })
   }
 
-  async updateStackOpenDeck(gameId: UUID, playerId: UUID, updater: (cardsDeck: CardsDeck) => CardsDeck) {
-    const deck = await this.getStackOpenDeck(gameId, playerId)
+  updateStackOpenDeck(gameId: UUID, playerId: UUID, updater: (cardsDeck: CardsDeck) => CardsDeck) {
+    const deck = this.getStackOpenDeck(gameId, playerId)
     if (!deck) {
       return
     }

--- a/apps/ligretto-gameplay-backend/src/entities/player/player.service.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/player/player.service.ts
@@ -8,73 +8,73 @@ import { IOC_TYPES } from '../../IOC_TYPES'
 export class PlayerService {
   @inject(IOC_TYPES.PlayerRepository) private playerRepository: PlayerRepository
 
-  async getPlayer(gameId: UUID, playerId: UUID) {
-    return await this.playerRepository.getPlayer(gameId, playerId)
+  getPlayer(gameId: UUID, playerId: UUID) {
+    return this.playerRepository.getPlayer(gameId, playerId)
   }
 
-  async getCard(gameId: UUID, playerId: UUID, position: number) {
-    return await this.playerRepository.getCard(gameId, playerId, position)
+  getCard(gameId: UUID, playerId: UUID, position: number) {
+    return this.playerRepository.getCard(gameId, playerId, position)
   }
 
-  async addCard(gameId: UUID, playerId: UUID, card: Card) {
-    const cards = await this.playerRepository.getCards(gameId, playerId)
+  addCard(gameId: UUID, playerId: UUID, card: Card) {
+    const cards = this.playerRepository.getCards(gameId, playerId)
 
     const emptyCardIndex = cards?.findIndex(card => card === null)
 
     if (emptyCardIndex !== undefined && emptyCardIndex !== -1) {
-      await this.playerRepository.addCard(gameId, playerId, card, emptyCardIndex)
+      this.playerRepository.addCard(gameId, playerId, card, emptyCardIndex)
     }
   }
 
-  async removeCard(gameId: UUID, playerId: UUID, position: number) {
-    await this.playerRepository.removeCard(gameId, playerId, position)
+  removeCard(gameId: UUID, playerId: UUID, position: number) {
+    this.playerRepository.removeCard(gameId, playerId, position)
 
     return undefined
   }
 
-  async removeCardFromLigrettoDeck(gameId: UUID, playerId: UUID) {
+  removeCardFromLigrettoDeck(gameId: UUID, playerId: UUID) {
     return this.playerRepository.removeCardFromLigrettoDeck(gameId, playerId)
   }
 
-  async removeCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
-    await this.playerRepository.removeCardFromStackOpenDeck(gameId, playerId)
-    return await this.getCardFromStackOpenDeck(gameId, playerId)
+  removeCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
+    this.playerRepository.removeCardFromStackOpenDeck(gameId, playerId)
+    return this.getCardFromStackOpenDeck(gameId, playerId)
   }
 
-  async getCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
-    const deck = await this.playerRepository.getStackOpenDeck(gameId, playerId)
+  getCardFromStackOpenDeck(gameId: UUID, playerId: UUID) {
+    const deck = this.playerRepository.getStackOpenDeck(gameId, playerId)
 
     return last(deck?.cards)
   }
 
-  async shuffleStackDeck(gameId: UUID, playerId: UUID) {
-    const stackOpenDeck = await this.playerRepository.getStackOpenDeck(gameId, playerId)
-    const stackDeck = await this.playerRepository.getStackDeck(gameId, playerId)
+  shuffleStackDeck(gameId: UUID, playerId: UUID) {
+    const stackOpenDeck = this.playerRepository.getStackOpenDeck(gameId, playerId)
+    const stackDeck = this.playerRepository.getStackDeck(gameId, playerId)
 
     if (stackDeck?.cards.length !== 0) {
       return
     }
 
-    await this.playerRepository.updateStackDeck(gameId, playerId, stackDeck => ({
+    this.playerRepository.updateStackDeck(gameId, playerId, stackDeck => ({
       ...stackDeck,
       cards: shuffle(stackOpenDeck?.cards),
     }))
 
-    await this.playerRepository.updateStackOpenDeck(gameId, playerId, stackOpenDeck => ({
+    this.playerRepository.updateStackOpenDeck(gameId, playerId, stackOpenDeck => ({
       ...stackOpenDeck,
       cards: [],
     }))
   }
 
-  async takeFromStackDeck(gameId: UUID, playerId: UUID) {
-    const stackDeck = await this.playerRepository.getStackDeck(gameId, playerId)
+  takeFromStackDeck(gameId: UUID, playerId: UUID) {
+    const stackDeck = this.playerRepository.getStackDeck(gameId, playerId)
     if (stackDeck?.cards.length === 0) {
-      await this.shuffleStackDeck(gameId, playerId)
+      this.shuffleStackDeck(gameId, playerId)
     }
 
     let cards: Card[] = []
 
-    await this.playerRepository.updateStackDeck(gameId, playerId, stackDeck => {
+    this.playerRepository.updateStackDeck(gameId, playerId, stackDeck => {
       cards = stackDeck.cards.slice(-3)
 
       return {
@@ -83,7 +83,7 @@ export class PlayerService {
       }
     })
 
-    await this.playerRepository.updateStackOpenDeck(gameId, playerId, stackOpenDeck => ({
+    this.playerRepository.updateStackOpenDeck(gameId, playerId, stackOpenDeck => ({
       ...stackOpenDeck,
       cards: stackOpenDeck.cards.concat(cards),
     }))
@@ -97,9 +97,9 @@ export class PlayerService {
    * @param gameId
    * @param playerId
    */
-  async takeFromLigrettoDeck(gameId: UUID, playerId: string) {
-    const cards = await this.playerRepository.getCards(gameId, playerId)
-    const ligrettoDeck = await this.playerRepository.getLigrettoDeck(gameId, playerId)
+  takeFromLigrettoDeck(gameId: UUID, playerId: string) {
+    const cards = this.playerRepository.getCards(gameId, playerId)
+    const ligrettoDeck = this.playerRepository.getLigrettoDeck(gameId, playerId)
 
     const emptyCardIndex = cards?.findIndex(card => card === null)
     if (emptyCardIndex === -1) {
@@ -112,7 +112,7 @@ export class PlayerService {
       return
     }
 
-    await this.addCard(gameId, playerId, card)
-    return await this.removeCardFromLigrettoDeck(gameId, playerId)
+    this.addCard(gameId, playerId, card)
+    return this.removeCardFromLigrettoDeck(gameId, playerId)
   }
 }

--- a/apps/ligretto-gameplay-backend/src/entities/playground/playground.repo.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/playground/playground.repo.ts
@@ -29,8 +29,8 @@ export class PlaygroundRepository {
     })
   }
 
-  async updateDeck(gameId: UUID, position: number, updater: (deck: CardsDeck | null) => CardsDeck) {
-    const deck = await this.getDeck(gameId, position)
+  updateDeck(gameId: UUID, position: number, updater: (deck: CardsDeck | null) => CardsDeck) {
+    const deck = this.getDeck(gameId, position)
 
     return this.database.set(storage => {
       const updated = updater(deck)

--- a/apps/ligretto-gameplay-backend/src/entities/playground/playground.service.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/playground/playground.service.ts
@@ -16,23 +16,23 @@ const isDeckAvailable = (deck: CardsDeck | null, card: Card) => {
 export class PlaygroundService {
   @inject(IOC_TYPES.PlaygroundRepository) private playgroundRepository: PlaygroundRepository
 
-  async getDecks(gameId: UUID) {
-    return await this.playgroundRepository.getDecks(gameId)
+  getDecks(gameId: UUID) {
+    return this.playgroundRepository.getDecks(gameId)
   }
 
-  async findAvailableDeckIndex(gameId: UUID, card: Card) {
-    const decks = await this.getDecks(gameId)
+  findAvailableDeckIndex(gameId: UUID, card: Card) {
+    const decks = this.getDecks(gameId)
     return decks.findIndex(deck => isDeckAvailable(deck, card))
   }
 
-  async putCard(gameId: UUID, card: Card, deckIndex: number) {
-    const deck = await this.playgroundRepository.getDeck(gameId, deckIndex)
+  putCard(gameId: UUID, card: Card, deckIndex: number) {
+    const deck = this.playgroundRepository.getDeck(gameId, deckIndex)
 
     if (!isDeckAvailable(deck, card)) {
       return
     }
 
-    await this.playgroundRepository.updateDeck(gameId, deckIndex, deck =>
+    this.playgroundRepository.updateDeck(gameId, deckIndex, deck =>
       deck
         ? {
             ...deck,
@@ -41,17 +41,17 @@ export class PlaygroundService {
         : { cards: [card], isHidden: false },
     )
     if (card.value === 10) {
-      const updatedDeck = await this.playgroundRepository.getDeck(gameId, deckIndex)
+      const updatedDeck = this.playgroundRepository.getDeck(gameId, deckIndex)
 
       if (updatedDeck) {
-        await this.playgroundRepository.addDroppedDeck(gameId, updatedDeck)
-        await this.playgroundRepository.removeDeck(gameId, deckIndex)
+        this.playgroundRepository.addDroppedDeck(gameId, updatedDeck)
+        this.playgroundRepository.removeDeck(gameId, deckIndex)
       }
     }
   }
 
-  async checkIsDeckAvailable(gameId: UUID, card: Card, position: number) {
-    const deck = await this.playgroundRepository.getDeck(gameId, position)
+  checkIsDeckAvailable(gameId: UUID, card: Card, position: number) {
+    const deck = this.playgroundRepository.getDeck(gameId, position)
     const topCard: Card | undefined = last(deck?.cards)
 
     if (!deck) {
@@ -69,12 +69,12 @@ export class PlaygroundService {
    * if deckPosition passed, check this deck
    * else find available deck position
    */
-  async getAvailableDeckPosition(gameId: Game['id'], card: Card, deckPosition?: number): Promise<number | undefined> {
+  getAvailableDeckPosition(gameId: Game['id'], card: Card, deckPosition?: number): number | undefined {
     let finalDeckPosition: number | undefined
     if (deckPosition !== undefined) {
-      finalDeckPosition = (await this.checkIsDeckAvailable(gameId, card, deckPosition)) ? deckPosition : undefined
+      finalDeckPosition = this.checkIsDeckAvailable(gameId, card, deckPosition) ? deckPosition : undefined
     } else {
-      finalDeckPosition = await this.findAvailableDeckIndex(gameId, card)
+      finalDeckPosition = this.findAvailableDeckIndex(gameId, card)
     }
 
     return finalDeckPosition

--- a/apps/ligretto-gameplay-backend/src/entities/user/user.service.ts
+++ b/apps/ligretto-gameplay-backend/src/entities/user/user.service.ts
@@ -16,8 +16,8 @@ export class UserService {
     return this.userRepository.updateUser({ id: userId, currentGameId: gameId })
   }
 
-  async disconnectionHandler({ socketId, userId }: { socketId: string; userId: User['id'] }) {
-    const user = await this.getUser(userId)
+  disconnectionHandler({ socketId, userId }: { socketId: string; userId: User['id'] }) {
+    const user = this.getUser(userId)
 
     if (!user) {
       return

--- a/apps/ligretto-gameplay-backend/src/gameplay/gameplay.ts
+++ b/apps/ligretto-gameplay-backend/src/gameplay/gameplay.ts
@@ -11,47 +11,47 @@ export class Gameplay {
   @inject(IOC_TYPES.PlayerService) private playerService: PlayerService
   @inject(IOC_TYPES.PlaygroundService) private playgroundService: PlaygroundService
 
-  async startGame(gameId: UUID) {
+  startGame(gameId: UUID) {
     try {
-      await this.gameService.startGame(gameId)
+      this.gameService.startGame(gameId)
     } catch (e) {
       console.log(e)
     }
   }
 
-  async playerPutCard(gameId: UUID, playerId: UUID, cardPosition: number, deckPosition?: number) {
+  playerPutCard(gameId: UUID, playerId: UUID, cardPosition: number, deckPosition?: number) {
     try {
-      const card = await this.playerService.getCard(gameId, playerId, cardPosition)
+      const card = this.playerService.getCard(gameId, playerId, cardPosition)
       if (!card) {
         return
       }
 
-      const finalDeckPosition = await this.playgroundService.getAvailableDeckPosition(gameId, card, deckPosition)
+      const finalDeckPosition = this.playgroundService.getAvailableDeckPosition(gameId, card, deckPosition)
       if (finalDeckPosition === undefined || finalDeckPosition === -1) {
         return
       }
 
-      await this.playgroundService.putCard(gameId, card, finalDeckPosition)
-      await this.playerService.removeCard(gameId, playerId, cardPosition)
+      this.playgroundService.putCard(gameId, card, finalDeckPosition)
+      this.playerService.removeCard(gameId, playerId, cardPosition)
     } catch (e) {
       console.log(e)
     }
   }
 
-  async playerPutFromStackOpenDeck(gameId: UUID, playerId: UUID, deckPosition?: number) {
+  playerPutFromStackOpenDeck(gameId: UUID, playerId: UUID, deckPosition?: number) {
     try {
-      const card = await this.playerService.getCardFromStackOpenDeck(gameId, playerId)
+      const card = this.playerService.getCardFromStackOpenDeck(gameId, playerId)
       if (!card) {
         return
       }
-      const finalDeckPosition = await this.playgroundService.getAvailableDeckPosition(gameId, card, deckPosition)
+      const finalDeckPosition = this.playgroundService.getAvailableDeckPosition(gameId, card, deckPosition)
 
       if (finalDeckPosition === -1 || finalDeckPosition === undefined) {
         return
       }
 
-      await this.playgroundService.putCard(gameId, card, finalDeckPosition)
-      await this.playerService.removeCardFromStackOpenDeck(gameId, playerId)
+      this.playgroundService.putCard(gameId, card, finalDeckPosition)
+      this.playerService.removeCardFromStackOpenDeck(gameId, playerId)
     } catch (e) {
       console.log(e)
     }
@@ -59,13 +59,13 @@ export class Gameplay {
 
   async playerTakeFromLigrettoDeck(gameId: UUID, playerId: UUID): Promise<{ game?: Game; gameResults?: GameResults }> {
     try {
-      const remaining = await this.playerService.takeFromLigrettoDeck(gameId, playerId)
+      const remaining = this.playerService.takeFromLigrettoDeck(gameId, playerId)
 
       if (remaining === 0) {
-        return this.gameService.finishRound(gameId)
+        return await this.gameService.finishRound(gameId)
       }
 
-      const game = await this.gameService.getGame(gameId)
+      const game = this.gameService.getGame(gameId)
       return { game }
     } catch (e) {
       console.log(e)
@@ -73,9 +73,9 @@ export class Gameplay {
     }
   }
 
-  async playerTakeFromStackDeck(gameId: UUID, playerId: UUID) {
+  playerTakeFromStackDeck(gameId: UUID, playerId: UUID) {
     try {
-      await this.playerService.takeFromStackDeck(gameId, playerId)
+      this.playerService.takeFromStackDeck(gameId, playerId)
     } catch (e) {
       console.log(e)
     }
@@ -83,7 +83,7 @@ export class Gameplay {
 
   async endGame(gameId: UUID) {
     try {
-      const roundResult = await this.gameService.getRoundResult(gameId)
+      const roundResult = this.gameService.getRoundResult(gameId)
       await this.gameService.endGame(gameId)
 
       return { roundResult }

--- a/apps/ligretto-gameplay-backend/src/websocket-handlers/handler.ts
+++ b/apps/ligretto-gameplay-backend/src/websocket-handlers/handler.ts
@@ -20,7 +20,7 @@ export class WebSocketHandler {
     socketServer.use(authMiddleware).on('connection', socket => this.connectionHandler(socket))
   }
 
-  public async connectionHandler(socket: Socket): Promise<void> {
+  public connectionHandler(socket: Socket): void {
     socketIOConnectionsCountMetric.inc()
     socketIOConnectionsCountTotalMetric.inc()
 
@@ -37,16 +37,16 @@ export class WebSocketHandler {
       socket.emit(data.type, data.payload)
     })
 
-    socket.on('disconnecting', async () => {
-      await this.gamesController.disconnectionHandler(socket)
-      await this.userService.disconnectionHandler({ socketId: socket.id, userId: socket.data.user.id })
+    socket.on('disconnecting', () => {
+      this.gamesController.disconnectionHandler(socket)
+      this.userService.disconnectionHandler({ socketId: socket.id, userId: socket.data.user.id })
     })
 
     socket.on('disconnect', () => {
       socketIOConnectionsCountMetric.dec()
     })
 
-    await this.userService.connectUser({ socketId: socket.id, userId: socket.data.user.id })
+    this.userService.connectUser({ socketId: socket.id, userId: socket.data.user.id })
   }
 
   private messageHandler(socket: Socket, data: AnyAction) {


### PR DESCRIPTION
## Summary

The gameplay backend's in-memory `Database` had an async `get`/`set` API left over from a planned move to remote storage that we have since decided against. The fake asynchronicity was the root cause of our concurrency problems: every `await Promise.resolve(...)` yielded to the microtask queue, opening interleaving windows where concurrent socket handlers and timers could race through multi-step check-then-act sequences.

This PR makes the storage layer synchronous and propagates synchronicity all the way up (repositories → services → `Gameplay` → controllers → websocket handler), so every read-modify-write chain over game state is atomic by construction in single-threaded JS.

## Changes

- `Database.get`/`set` are synchronous; the unused update-listener API (`addUpdateListener`/`removeUpdateListener`) and the dead module-level `storage` export are removed
- `GameRepository`, `UserRepository`, `PlayerRepository`, `PlaygroundRepository` are synchronous
- `UserService`, `PlayerService`, `PlaygroundService` and most of `GameService` are synchronous; every gameplay move in `Gameplay` is now a synchronous, atomic chain
- Controllers and the websocket handler call the synchronous paths directly, making whole handlers (`joinGame`, `leaveFromRoomHandler`, `resumeGame`, all moves) atomic

## Genuinely async boundaries

Only real I/O stays async — HTTP calls to ligretto-core-backend — and is now guarded against concurrent mutation instead of relying on ordering:

- **`createGame`** re-checks the room name atomically after the HTTP call, so two concurrent creations of the same name can no longer both add a room
- **`finishRound`** atomically claims the round finish (transitions the game to `RoundFinished` and snapshots the results *before* the HTTP save), so a round can no longer be saved twice — previously two players emptying their ligretto decks during the save window caused a double save. The claim is released if the save fails
- the `startGame` countdown keeps its existing `Starting`-status flow

## Tests

Removed the two resume-game tests that exercised a concurrent mutation interleaving mid-handler (`broadcasts the freshest canonical game after resuming`, `does not allow a stale former host to resume or broadcast`): with synchronous handling their scenario is structurally impossible. The regression test from #647 (`resumes a paused game without changing its in-progress state`) stays.

## Validation

- gameplay backend: 17/17 tests, `tsc --noEmit` clean
- workspace `pnpm lint:check`, `pnpm fmt:check`
- pre-existing failures unrelated to this diff: `apps/blog` ts-check (stale generated `.next` types) and `ligretto-core-backend` tests (documented since the Adonis v7 upgrade)

## Notes for reviewers

- PR #648 (resilient connection lifecycle, #644) is deferred and will be rebased onto this model; its `GameOperationSerializer` becomes unnecessary
- If remote/multi-instance storage ever returns, per-process ordering wouldn't survive anyway — that future needs distributed locking regardless of this change

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)
