### PR TITLE
fix(ligretto): serialize array query params as repeated keys

### DIFF
--- a/apps/ligretto-frontend/src/shared/api/request.spec.ts
+++ b/apps/ligretto-frontend/src/shared/api/request.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildSearchParams, request } from './request'
+
+describe('buildSearchParams', () => {
+  it('repeats array params instead of comma-joining them', () => {
+    const params = buildSearchParams({ ids: ['6a932978f77c9c7a7951e541', '6a93297bf77c9cb1a451e542'] })
+
+    expect(params.toString()).toBe('ids=6a932978f77c9c7a7951e541&ids=6a93297bf77c9cb1a451e542')
+  })
+
+  it('serializes flat values and skips nullish ones', () => {
+    const params = buildSearchParams({ page: 2, search: 'abc', empty: undefined, missing: null })
+
+    expect(params.toString()).toBe('page=2&search=abc')
+  })
+})
+
+describe('request', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fetches users with repeated ids params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await request.get('/users', { params: { ids: ['6a932978f77c9c7a7951e541', '6a93297bf77c9cb1a451e542'] } })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toContain('/users?ids=6a932978f77c9c7a7951e541&ids=6a93297bf77c9cb1a451e542')
+  })
+})

--- a/apps/ligretto-frontend/src/shared/api/request.ts
+++ b/apps/ligretto-frontend/src/shared/api/request.ts
@@ -1,9 +1,27 @@
 import { LIGRETTO_CORE_URL } from '#shared/constants/config'
 
+// Flat params only (strings, numbers, arrays); arrays are repeated: ids=a&ids=b
+export const buildSearchParams = (params: Record<string, unknown>): URLSearchParams => {
+  const searchParams = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) {
+      continue
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item))
+      }
+    } else {
+      searchParams.append(key, String(value))
+    }
+  }
+  return searchParams
+}
+
 async function fetchRequest<T>(method: string, path: string, body?: unknown, params?: Record<string, unknown>): Promise<{ data: T }> {
   let url = `${LIGRETTO_CORE_URL}${path}`
   if (params) {
-    url += `?${new URLSearchParams(params as Record<string, string>).toString()}`
+    url += `?${buildSearchParams(params).toString()}`
   }
   const response = await fetch(url, {
     method,


### PR DESCRIPTION
## Problem

Opening a game room that already contains other players left opponent rows without usernames/avatars/connection badges. The frontend fetched profiles with `ids` comma-joined into a single query value (`ids=a,b`), because `new URLSearchParams(params)` stringifies array values. The core backend's `ensureArray` wrapped that string into a one-element array that passed its own vine check, but CAS then rejected the combined string against its 24-hex id pattern, so the request failed, `usersMap` stayed empty, and `opponentsSelector` filtered the players out. Single-id fetches worked, which is why late joiners rendered fine.

## Fix

Serialize array params as repeated keys (`ids=a&ids=b`) in the frontend request layer, mirroring the `buildSearchParams` convention already documented in `packages/cas-services/src/request.ts`. The core backend's `qs()` parsing + `ensureArray` already accept this shape, so no backend change is needed.

## Testing

- New `request.spec.ts` covers repeated-array serialization, nullish-param skipping, and the multi-id `/users` fetch URL via a mocked `fetch`.
- `pnpm ts-check`, `pnpm test:ci` (63 tests) in `apps/ligretto-frontend`, root `pnpm lint:check` and `pnpm fmt:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)