### PR TITLE
fix(ligretto): keep socket identity in sync with the authenticated user

### DIFF
--- a/apps/ligretto-frontend/e2e/tests/game.spec.ts
+++ b/apps/ligretto-frontend/e2e/tests/game.spec.ts
@@ -128,3 +128,65 @@ test.describe('Connection lifecycle', () => {
     await Promise.all([contextUser1.close(), contextUser2.close()])
   })
 })
+
+test.describe('Direct game link', () => {
+  /**
+   * Regression for the identity race on a cold /game/:id load: the auth
+   * bootstrap used to run once per dispatch of the nested connect-to-room
+   * cascade, minting several temporary users at once. The socket then joined
+   * the room as one guest while redux rendered as another, so the joiner saw
+   * no own cards and every player as an opponent.
+   */
+  test('seats a fresh guest who opens the game link directly', async ({ browser }, testInfo) => {
+    test.setTimeout(60_000)
+    const contextUser1 = await browser.newContext()
+    const pageUser1 = await contextUser1.newPage()
+
+    const homePageUser1 = new HomePage(pageUser1)
+    await homePageUser1.visitHomeUrl()
+    await (await homePageUser1.getRoomNameInput()).click()
+    // Unique per run (room names max out at 20 chars): rooms linger on the
+    // backend until the all-offline deletion timeout, so a retry-based suffix
+    // alone can collide across invocations.
+    await (await homePageUser1.getRoomNameInput()).fill(`Direct-${testInfo.retry}-${Date.now().toString(36)}`)
+    await (await homePageUser1.getCreateGameButton()).click()
+
+    const gamePageUser1 = new GamePage(pageUser1)
+    await expect(await gamePageUser1.getPlayerReadyButton()).toBeVisible()
+
+    // A brand-new context holds no auth token, and the page lands straight on
+    // the game URL — the exact cold load the identity race was triggered by.
+    const contextUser2 = await browser.newContext()
+    const pageUser2 = await contextUser2.newPage()
+    await pageUser2.goto(pageUser1.url())
+
+    const gamePageUser2 = new GamePage(pageUser2)
+    await expect(await gamePageUser2.getPlayersList()).toHaveCount(2)
+
+    const readyButton = await gamePageUser2.getPlayerReadyButton()
+    await expect(readyButton).toHaveText('Ready')
+    await readyButton.click()
+
+    const startButton = await gamePageUser1.getPlayerReadyButton()
+    await expect(startButton).toHaveText('Start')
+    await expect(startButton).toBeEnabled()
+    await startButton.click()
+
+    // The joiner is a seated player, not an accidental spectator: their own
+    // deck is dealt and rendered, and the creator is their only opponent.
+    await expect(gamePageUser2.getOwnLigrettoDeck()).toBeVisible({ timeout: 15_000 })
+    await expect(gamePageUser2.getOpponents()).toHaveCount(1)
+    await expect(gamePageUser1.getOwnLigrettoDeck()).toBeVisible()
+    await expect(gamePageUser1.getOpponents()).toHaveCount(1)
+
+    // No phantom guests joined along the way: once the disconnect grace would
+    // have expired, nobody is offline and the round is not paused.
+    await pageUser2.waitForTimeout(6_000)
+    await expect(pageUser1.getByText('Round is paused')).toBeHidden()
+    await expect(pageUser2.getByText('Round is paused')).toBeHidden()
+    await expect(gamePageUser1.getDisconnectedBadges()).toHaveCount(0)
+    await expect(gamePageUser2.getDisconnectedBadges()).toHaveCount(0)
+
+    await Promise.all([contextUser1.close(), contextUser2.close()])
+  })
+})

--- a/apps/ligretto-frontend/src/app/store/listenerMiddleware.ts
+++ b/apps/ligretto-frontend/src/app/store/listenerMiddleware.ts
@@ -19,10 +19,17 @@ usersAddListener(startAppListening)
 authAddListener(startAppListening)
 onboardingAddListener(startAppListening)
 
-const unsubscribeSocket = startAppListening({
+let socketStarted = false
+startAppListening({
   actionCreator: getMeSuccess,
-  effect: async (_action, listenerApi) => {
-    socketAddListener(startAppListening, listenerApi.dispatch)
-    unsubscribeSocket()
+  effect: (action, listenerApi) => {
+    // A plain flag instead of unsubscribe(): RTK snapshots the listener map
+    // per dispatch, so unsubscribe alone does not stop re-entrant dispatches
+    // that are already in flight.
+    if (socketStarted) {
+      return
+    }
+    socketStarted = true
+    socketAddListener(startAppListening, listenerApi.dispatch, action.payload.token)
   },
 })

--- a/apps/ligretto-frontend/src/ducks/auth/listeners.ts
+++ b/apps/ligretto-frontend/src/ducks/auth/listeners.ts
@@ -29,6 +29,12 @@ export function addListeners(startListener: TypedStartListening<All>) {
   startListener({
     actionCreator: getMeRequest,
     effect: async ({ payload }, listenerApi) => {
+      // The reducer sets isLoading synchronously, so a value of `true` *before*
+      // this action means another identity request is already in flight — a
+      // duplicate would mint a second temporary user on the backend.
+      if (listenerApi.getOriginalState().auth.isLoading) {
+        return
+      }
       const user = await getUserByTokenEffect(payload.token)
 
       if (!user) {
@@ -71,16 +77,6 @@ export function addListeners(startListener: TypedStartListening<All>) {
     effect: async (_action, listenerApi) => {
       window.localStorage.removeItem(LOCAL_STORAGE_TOKEN_KEY)
       listenerApi.dispatch(getMeRequest({}))
-    },
-  })
-
-  // Initialize auth on app start
-  const unsubscribeInitAuth = startListener({
-    predicate: () => true,
-    effect: async (_action, listenerApi) => {
-      unsubscribeInitAuth()
-      const token = window.localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY) ?? undefined
-      listenerApi.dispatch(getMeRequest({ token }))
     },
   })
 }

--- a/apps/ligretto-frontend/src/entities/socket/model/listeners.ts
+++ b/apps/ligretto-frontend/src/entities/socket/model/listeners.ts
@@ -4,15 +4,17 @@ import type { All } from '#types/store'
 import type { Socket } from 'socket.io-client'
 import { io } from 'socket.io-client'
 import { LIGRETTO_GAMEPLAY_URL } from '#shared/constants/config'
-import { LOCAL_STORAGE_TOKEN_KEY } from '#ducks/auth/constants'
 import { socketConnectedAction } from './actions'
 
-export function addListeners(startListener: TypedStartListening<All>, dispatch: Dispatch) {
+export function addListeners(startListener: TypedStartListening<All>, dispatch: Dispatch, token: string) {
   let socket: Socket
   try {
+    // The token comes from the same getMeSuccess that set auth.userId, so the
+    // socket identity cannot diverge from the one the UI renders with —
+    // localStorage may already hold a token from a concurrent getMe response.
     socket = io(LIGRETTO_GAMEPLAY_URL, {
       auth: {
-        token: window.localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY),
+        token,
       },
     })
   } catch (e) {

--- a/apps/ligretto-frontend/src/features/player/ui/LigrettoDeckContainer.tsx
+++ b/apps/ligretto-frontend/src/features/player/ui/LigrettoDeckContainer.tsx
@@ -29,6 +29,7 @@ export const LigrettoDeckContainer = () => {
 
   return (
     <LigrettoPack
+      dataTestId="LigrettoDeck"
       count={ligrettoDeckCards.length}
       isDndEnabled={isLigrettoDeckEnabled}
       ligrettoDeckCards={ligrettoDeckCards}

--- a/apps/ligretto-frontend/src/index.tsx
+++ b/apps/ligretto-frontend/src/index.tsx
@@ -6,6 +6,8 @@ import { ThemeProvider, CssBaseline } from '@memebattle/ui'
 import { HistoryRouter as Router } from 'redux-first-history/rr6'
 import { store, history } from './app/store'
 
+import { getMeRequest } from '#ducks/auth'
+import { LOCAL_STORAGE_TOKEN_KEY } from '#ducks/auth/constants'
 import { theme } from './app/themes/default'
 import { AppContainer } from './app/AppContainer'
 
@@ -16,6 +18,12 @@ if (!reactRootContainer) {
 }
 
 const root = createRoot(reactRootContainer)
+
+// A single explicit auth bootstrap. Doing this with a fire-on-any-action
+// listener is unsafe: nested dispatch cascades (e.g. the connect-to-room chain
+// on a direct /game/:id load) run it once per snapshotted dispatch, minting
+// several temporary users at once.
+store.dispatch(getMeRequest({ token: window.localStorage.getItem(LOCAL_STORAGE_TOKEN_KEY) ?? undefined }))
 
 root.render(
   <StrictMode>

--- a/apps/ligretto-frontend/src/pages/game/GamePage.page-object.ts
+++ b/apps/ligretto-frontend/src/pages/game/GamePage.page-object.ts
@@ -26,4 +26,13 @@ export class GamePage {
   getDisconnectedBadges() {
     return this.page.getByTitle(/\(disconnected\)$/)
   }
+
+  /** Rendered only when the viewer is a seated player with dealt cards. */
+  getOwnLigrettoDeck() {
+    return this.page.getByTestId('LigrettoDeck')
+  }
+
+  getOpponents() {
+    return this.page.locator('[data-connection-state]')
+  }
 }


### PR DESCRIPTION
## Bug

Opening a direct `/game/:id` link in a browser with no stored token (fresh browser, incognito) broke the second player's view: the game board rendered with **no own cards**, both seats showed as **opponents**, and a few seconds later the round **paused**. The host's view stayed fine. Reported while testing #648.

## Root cause

A cold load of the game route dispatches a nested cascade: `LOCATION_CHANGE` → `connectToRoom` → `WEBSOCKET/CONNECT_TO_ROOM`. The auth-init listener (`predicate: () => true` + unsubscribe inside the effect) relied on unsubscribing synchronously, but RTK's listener middleware snapshots the listener map per dispatch — each nested dispatch already in flight ran the listener again. Result: **three parallel tokenless `POST /auth/me`**, each minting a different temporary user (the endpoint is not idempotent without a token).

Each response wrote its token to `localStorage` and dispatched its own `getMeSuccess`. The socket was created once, reading whatever token `localStorage` held at that moment, while redux kept the user of the last response. The seat at the table (keyed by the socket's token identity) belonged to one guest, the UI rendered as another → "не игрок". Once the phantom guests dropped, the disconnect grace from the connection lifecycle paused the round.

The race predates #648 — reproduced identically on `1ce0dff9` with a parallel stack — but the lifecycle's seat retention and pause made it much more visible. Joining via the home page fires a single request, which is why the flow through the lobby never showed it.

## Fix

- Bootstrap auth with a single explicit `store.dispatch(getMeRequest(...))` from the entry point instead of a fire-on-any-action listener.
- Drop concurrent `getMeRequest` effects while one is in flight (`getOriginalState().auth.isLoading` — the reducer sets it synchronously), so a duplicate dispatch can never mint a second guest.
- Create the socket with the token from the same `getMeSuccess` payload that set `auth.userId` instead of re-reading `localStorage`, and guard the one-shot socket setup with a flag rather than `unsubscribe()`.

## Verification

- `ts-check`, `oxlint`, unit tests (65 passed).
- Live repro of the exact failing flow (fresh guest → direct game link → ready → start): exactly **one** temporary user created (was 3), `auth.userId` == socket token == seat key, second player sees their cards and one opponent, no pause.
- Reconnect from #648 still works: reloading the second player mid-round restores the same identity, seat, and hand.

## Left out deliberately

`POST /auth/me` without a token still mints a new temporary user per call on the core backend. The frontend now sends exactly one request, but the endpoint itself remains non-idempotent — worth a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)