### PR TITLE
feat(cas): unified API error model

### DIFF
--- a/apps/cas/src/error.rs
+++ b/apps/cas/src/error.rs
@@ -1,0 +1,62 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error, miette::Diagnostic)]
+pub enum ApiError {
+    #[diagnostic(code(cas::invalid_registration_id))]
+    #[error("Invalid registration id: {0}")]
+    InvalidRegistrationId(#[source] uuid::Error),
+
+    #[diagnostic(code(cas::registration_state_not_found))]
+    #[error("Registration state not found")]
+    RegistrationStateNotFound,
+
+    #[diagnostic(code(cas::registration_verification_failed))]
+    #[error("Failed to verify registration: {0}")]
+    VerifyRegistration(#[source] webauthn_rs::prelude::WebauthnError),
+
+    #[diagnostic(code(cas::internal_error))]
+    #[error("Internal server error")]
+    Internal(#[source] webauthn_rs::prelude::WebauthnError),
+}
+
+impl ApiError {
+    fn status(&self) -> StatusCode {
+        match self {
+            ApiError::InvalidRegistrationId(_) => StatusCode::BAD_REQUEST,
+            ApiError::RegistrationStateNotFound => StatusCode::NOT_FOUND,
+            ApiError::VerifyRegistration(_) => StatusCode::BAD_REQUEST,
+            ApiError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            ApiError::InvalidRegistrationId(_) => "invalid_registration_id",
+            ApiError::RegistrationStateNotFound => "registration_state_not_found",
+            ApiError::VerifyRegistration(_) => "registration_verification_failed",
+            ApiError::Internal(_) => "internal_error",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = self.status();
+        if status.is_server_error() {
+            tracing::error!(error = ?self, "internal error");
+        }
+        let body = json!({
+            "error": {
+                "code": self.code(),
+                "message": self.to_string(),
+            }
+        });
+        (status, Json(body)).into_response()
+    }
+}

--- a/apps/cas/src/error.rs
+++ b/apps/cas/src/error.rs
@@ -4,59 +4,62 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde_json::json;
-use thiserror::Error;
 
-#[derive(Debug, Error, miette::Diagnostic)]
-pub enum ApiError {
-    #[diagnostic(code(cas::invalid_registration_id))]
-    #[error("Invalid registration id: {0}")]
-    InvalidRegistrationId(#[source] uuid::Error),
-
-    #[diagnostic(code(cas::registration_state_not_found))]
-    #[error("Registration state not found")]
-    RegistrationStateNotFound,
-
-    #[diagnostic(code(cas::registration_verification_failed))]
-    #[error("Failed to verify registration: {0}")]
-    VerifyRegistration(#[source] webauthn_rs::prelude::WebauthnError),
-
-    #[diagnostic(code(cas::internal_error))]
-    #[error("Internal server error")]
-    Internal(#[source] webauthn_rs::prelude::WebauthnError),
+/// Transport-level HTTP error contract.
+///
+/// Domain modules keep their own error enums and map them into this type
+/// via `From` impls, so the wire format stays in one place.
+#[derive(Debug)]
+pub struct ApiError {
+    status: StatusCode,
+    /// Stable machine-readable error code exposed to clients.
+    code: &'static str,
+    /// Client-facing message.
+    message: String,
+    /// Underlying error, logged for 5xx responses and never sent to clients.
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
 }
 
 impl ApiError {
-    fn status(&self) -> StatusCode {
-        match self {
-            ApiError::InvalidRegistrationId(_) => StatusCode::BAD_REQUEST,
-            ApiError::RegistrationStateNotFound => StatusCode::NOT_FOUND,
-            ApiError::VerifyRegistration(_) => StatusCode::BAD_REQUEST,
-            ApiError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    pub fn bad_request(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code,
+            message: message.into(),
+            source: None,
         }
     }
 
-    fn code(&self) -> &'static str {
-        match self {
-            ApiError::InvalidRegistrationId(_) => "invalid_registration_id",
-            ApiError::RegistrationStateNotFound => "registration_state_not_found",
-            ApiError::VerifyRegistration(_) => "registration_verification_failed",
-            ApiError::Internal(_) => "internal_error",
+    pub fn not_found(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code,
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn internal(source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal_error",
+            message: "Internal server error".to_owned(),
+            source: Some(source.into()),
         }
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let status = self.status();
-        if status.is_server_error() {
-            tracing::error!(error = ?self, "internal error");
+        if self.status.is_server_error() {
+            tracing::error!(code = self.code, source = ?self.source, "internal error");
         }
         let body = json!({
             "error": {
-                "code": self.code(),
-                "message": self.to_string(),
+                "code": self.code,
+                "message": self.message,
             }
         });
-        (status, Json(body)).into_response()
+        (self.status, Json(body)).into_response()
     }
 }

--- a/apps/cas/src/main.rs
+++ b/apps/cas/src/main.rs
@@ -1,4 +1,5 @@
 mod config;
+mod error;
 mod webauthn;
 
 use axum::{Router, routing::get};

--- a/apps/cas/src/webauthn.rs
+++ b/apps/cas/src/webauthn.rs
@@ -2,13 +2,51 @@ use std::{collections::HashMap, sync::Arc};
 
 use axum::{Json, Router, extract::State, routing::post};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
     CreationChallengeResponse, Passkey, PasskeyRegistration, RegisterPublicKeyCredential,
+    WebauthnError,
 };
 
 use crate::error::ApiError;
+
+#[derive(Debug, Error, miette::Diagnostic)]
+pub enum RegistrationError {
+    #[diagnostic(code(cas::invalid_registration_id))]
+    #[error("Invalid registration id: {0}")]
+    InvalidRegistrationId(#[source] uuid::Error),
+
+    #[diagnostic(code(cas::registration_state_not_found))]
+    #[error("Registration state not found")]
+    StateNotFound,
+
+    #[diagnostic(code(cas::registration_verification_failed))]
+    #[error("Failed to verify registration: {0}")]
+    Verify(#[source] WebauthnError),
+
+    #[diagnostic(code(cas::registration_start_failed))]
+    #[error("Failed to start registration: {0}")]
+    Start(#[source] WebauthnError),
+}
+
+impl From<RegistrationError> for ApiError {
+    fn from(err: RegistrationError) -> Self {
+        match &err {
+            RegistrationError::InvalidRegistrationId(_) => {
+                ApiError::bad_request("invalid_registration_id", err.to_string())
+            }
+            RegistrationError::StateNotFound => {
+                ApiError::not_found("registration_state_not_found", err.to_string())
+            }
+            RegistrationError::Verify(_) => {
+                ApiError::bad_request("registration_verification_failed", err.to_string())
+            }
+            RegistrationError::Start(_) => ApiError::internal(err),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UserId(pub Uuid);
@@ -51,7 +89,7 @@ async fn get_registration_options(
     let (ccr, skr) = state
         .webauthn
         .start_passkey_registration(user_id, "testuser", "testuser", None)
-        .map_err(ApiError::Internal)?;
+        .map_err(RegistrationError::Start)?;
     state
         .registration_state
         .lock()
@@ -69,18 +107,18 @@ async fn verify_registration(
     Json(data): Json<VerifyRegistrationData>,
 ) -> Result<Json<VerifyRegistrationResponse>, ApiError> {
     let user_id =
-        Uuid::parse_str(&data.registration_id).map_err(ApiError::InvalidRegistrationId)?;
+        Uuid::parse_str(&data.registration_id).map_err(RegistrationError::InvalidRegistrationId)?;
     let skr = state
         .registration_state
         .lock()
         .await
         .remove(&UserId(user_id))
-        .ok_or(ApiError::RegistrationStateNotFound)?;
+        .ok_or(RegistrationError::StateNotFound)?;
 
     let result = state
         .webauthn
         .finish_passkey_registration(&data.response, &skr)
-        .map_err(ApiError::VerifyRegistration)?;
+        .map_err(RegistrationError::Verify)?;
 
     Ok(Json(VerifyRegistrationResponse(result)))
 }

--- a/apps/cas/src/webauthn.rs
+++ b/apps/cas/src/webauthn.rs
@@ -1,19 +1,14 @@
 use std::{collections::HashMap, sync::Arc};
 
-use axum::{
-    Json, Router,
-    extract::State,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    routing::post,
-};
+use axum::{Json, Router, extract::State, routing::post};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use webauthn_rs::prelude::{
     CreationChallengeResponse, Passkey, PasskeyRegistration, RegisterPublicKeyCredential,
 };
+
+use crate::error::ApiError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UserId(pub Uuid);
@@ -42,30 +37,6 @@ pub struct VerifyRegistrationData {
 #[serde(rename_all = "camelCase")]
 pub struct VerifyRegistrationResponse(pub Passkey);
 
-#[derive(Debug, Error, miette::Diagnostic)]
-pub enum RegistrationError {
-    #[diagnostic(code(cas::registration_error))]
-    #[error("Failed to generate registration options: {0}")]
-    GenerateRegistrationOptionsError(webauthn_rs::prelude::WebauthnError),
-
-    #[diagnostic(code(cas::verify_registration_error))]
-    #[error("Failed to verify registration: {0}")]
-    VerifyRegistrationError(webauthn_rs::prelude::WebauthnError),
-}
-
-impl IntoResponse for RegistrationError {
-    fn into_response(self) -> Response {
-        match self {
-            RegistrationError::GenerateRegistrationOptionsError(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(e.to_string())).into_response()
-            }
-            RegistrationError::VerifyRegistrationError(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(e.to_string())).into_response()
-            }
-        }
-    }
-}
-
 pub fn router(state: ApiState) -> Router {
     Router::new()
         .route("/register-options", post(get_registration_options))
@@ -75,12 +46,12 @@ pub fn router(state: ApiState) -> Router {
 
 async fn get_registration_options(
     State(state): State<ApiState>,
-) -> Result<Json<RegistrationOptionsResponse>, RegistrationError> {
+) -> Result<Json<RegistrationOptionsResponse>, ApiError> {
     let user_id = Uuid::new_v4();
     let (ccr, skr) = state
         .webauthn
         .start_passkey_registration(user_id, "testuser", "testuser", None)
-        .map_err(RegistrationError::GenerateRegistrationOptionsError)?;
+        .map_err(ApiError::Internal)?;
     state
         .registration_state
         .lock()
@@ -96,19 +67,98 @@ async fn get_registration_options(
 async fn verify_registration(
     State(state): State<ApiState>,
     Json(data): Json<VerifyRegistrationData>,
-) -> Result<Json<VerifyRegistrationResponse>, RegistrationError> {
-    let user_id = Uuid::parse_str(&data.registration_id).unwrap();
+) -> Result<Json<VerifyRegistrationResponse>, ApiError> {
+    let user_id =
+        Uuid::parse_str(&data.registration_id).map_err(ApiError::InvalidRegistrationId)?;
     let skr = state
         .registration_state
         .lock()
         .await
         .remove(&UserId(user_id))
-        .expect("Registration state not found");
+        .ok_or(ApiError::RegistrationStateNotFound)?;
 
     let result = state
         .webauthn
         .finish_passkey_registration(&data.response, &skr)
-        .map_err(RegistrationError::VerifyRegistrationError)?;
+        .map_err(ApiError::VerifyRegistration)?;
 
     Ok(Json(VerifyRegistrationResponse(result)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode, header},
+    };
+    use tower::ServiceExt;
+    use webauthn_rs::prelude::Url;
+
+    fn test_app() -> Router {
+        let state = ApiState {
+            registration_state: Arc::new(Mutex::new(HashMap::new())),
+            webauthn: webauthn_rs::WebauthnBuilder::new(
+                "localhost",
+                &"http://localhost:5173".parse::<Url>().unwrap(),
+            )
+            .unwrap()
+            .build()
+            .unwrap(),
+        };
+        router(state)
+    }
+
+    fn verify_registration_request(registration_id: &str) -> Request<Body> {
+        let body = serde_json::json!({
+            "registrationId": registration_id,
+            "response": {
+                "id": "dGVzdA",
+                "rawId": "dGVzdA",
+                "response": {
+                    "attestationObject": "dGVzdA",
+                    "clientDataJSON": "dGVzdA",
+                    "transports": []
+                },
+                "type": "public-key",
+                "extensions": {}
+            }
+        });
+        Request::builder()
+            .method("POST")
+            .uri("/verify-registration")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    async fn error_body(response: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn verify_registration_with_invalid_registration_id_returns_400() {
+        let response = test_app()
+            .oneshot(verify_registration_request("not-a-uuid"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = error_body(response).await;
+        assert_eq!(body["error"]["code"], "invalid_registration_id");
+        assert!(body["error"]["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn verify_registration_with_unknown_registration_state_returns_404() {
+        let response = test_app()
+            .oneshot(verify_registration_request(&Uuid::new_v4().to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = error_body(response).await;
+        assert_eq!(body["error"]["code"], "registration_state_not_found");
+    }
 }


### PR DESCRIPTION
Error handling for the CAS API, split into a transport contract and per-module domain errors.

**`apps/cas/src/error.rs` — HTTP contract only.** `ApiError` is a plain struct carrying status, a stable machine-readable `code`, and a client-facing `message`, built via `bad_request(code, message)` / `not_found(code, message)` / `internal(source)`. Its `IntoResponse` renders the consistent JSON body `{"error": {"code": ..., "message": ...}}`; 500s send a generic "Internal server error" to the client while the underlying error goes to `tracing::error!`.

**`apps/cas/src/webauthn.rs` — domain errors stay in their module.** A `RegistrationError` enum (thiserror + miette) owns the registration failure semantics, and a single `From<RegistrationError> for ApiError` impl next to it defines the mapping:

- Invalid `registration_id` -> 400 `invalid_registration_id`
- Unknown/expired registration state -> 404 `registration_state_not_found`
- WebAuthn verification failure -> 400 `registration_verification_failed`
- WebAuthn start failure -> 500 `internal_error` with a generic message, details logged via `tracing::error!`

Rationale: `ApiError` is the single HTTP contract; each module owns its domain errors and their mapping, so future modules (login, sessions) add a `From` impl instead of growing a central enum.

Removes the `unwrap`/`expect` panics reachable from request input in `verify_registration`; all handlers return `Result<_, ApiError>` via `?`. Adds handler tests using `tower::ServiceExt::oneshot`.

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
