### PR TITLE
feat(cas): load configuration from environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ name = "cas"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "dotenvy",
  "miette",
  "serde",
  "serde_json",
@@ -342,6 +343,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "equivalent"

--- a/apps/cas/Cargo.toml
+++ b/apps/cas/Cargo.toml
@@ -8,6 +8,7 @@ name = "cas"
 
 [dependencies]
 axum = "0.8.9"
+dotenvy = "0.15.7"
 miette = "7.6.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -13,12 +13,12 @@ Configuration is read from environment variables at startup. Every variable has 
 | `CAS_ORIGIN` | `http://localhost:5173` | WebAuthn relying party origin URL. |
 | `CAS_CORS_ORIGINS` | `http://localhost:5173` | Comma-separated list of allowed CORS origins. |
 
-At startup the service also loads the monorepo root `.env` files, following the same dotenv-flow convention as the Node apps. `NODE_ENV` selects the environment and defaults to `development`; missing files are skipped. Priority, highest first:
+At startup the service also loads the monorepo root `.env` files. `APP_ENV` selects the environment and defaults to `development`; missing files are skipped. Priority, highest first:
 
 1. the real process environment
-2. `.env.{NODE_ENV}.local`
-3. `.env.{NODE_ENV}`
-4. `.env.local` (not loaded when `NODE_ENV` is `test`)
+2. `.env.{APP_ENV}.local`
+3. `.env.{APP_ENV}`
+4. `.env.local`
 5. `.env`
 
 ## Prepare bacon (used for dev server reload)

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -6,11 +6,11 @@ CAS (Central Authentication Service) is a centralized authentication and user ma
 
 Configuration is read from environment variables at startup. Every variable has a dev-friendly default, so `bacon run` works with no environment set. An invalid value fails startup with an error.
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `CAS_PORT` | `3000` | TCP port the server listens on. |
-| `CAS_RP_ID` | `localhost` | WebAuthn relying party ID. |
-| `CAS_ORIGIN` | `http://localhost:5173` | WebAuthn relying party origin URL. |
+| Variable           | Default                 | Description                                   |
+| ------------------ | ----------------------- | --------------------------------------------- |
+| `CAS_PORT`         | `3000`                  | TCP port the server listens on.               |
+| `CAS_RP_ID`        | `localhost`             | WebAuthn relying party ID.                    |
+| `CAS_ORIGIN`       | `http://localhost:5173` | WebAuthn relying party origin URL.            |
 | `CAS_CORS_ORIGINS` | `http://localhost:5173` | Comma-separated list of allowed CORS origins. |
 
 At startup the service also loads the monorepo root `.env` files. `APP_ENV` selects the environment and defaults to `development`; missing files are skipped. Priority, highest first:

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -13,6 +13,14 @@ Configuration is read from environment variables at startup. Every variable has 
 | `CAS_ORIGIN` | `http://localhost:5173` | WebAuthn relying party origin URL. |
 | `CAS_CORS_ORIGINS` | `http://localhost:5173` | Comma-separated list of allowed CORS origins. |
 
+At startup the service also loads the monorepo root `.env` files, following the same dotenv-flow convention as the Node apps. `NODE_ENV` selects the environment and defaults to `development`; missing files are skipped. Priority, highest first:
+
+1. the real process environment
+2. `.env.{NODE_ENV}.local`
+3. `.env.{NODE_ENV}`
+4. `.env.local` (not loaded when `NODE_ENV` is `test`)
+5. `.env`
+
 ## Prepare bacon (used for dev server reload)
 
 ```

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -2,6 +2,17 @@
 
 CAS (Central Authentication Service) is a centralized authentication and user management service for an ecosystem of applications. It serves as a single Identity Provider (IdP) that allows multiple applications to delegate user authentication and identity management, eliminating the need for each application to implement its own authentication system.
 
+## Configuration
+
+Configuration is read from environment variables at startup. Every variable has a dev-friendly default, so `bacon run` works with no environment set. An invalid value fails startup with an error.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CAS_PORT` | `3000` | TCP port the server listens on. |
+| `CAS_RP_ID` | `localhost` | WebAuthn relying party ID. |
+| `CAS_ORIGIN` | `http://localhost:5173` | WebAuthn relying party origin URL. |
+| `CAS_CORS_ORIGINS` | `http://localhost:5173` | Comma-separated list of allowed CORS origins. |
+
 ## Prepare bacon (used for dev server reload)
 
 ```

--- a/apps/cas/src/config.rs
+++ b/apps/cas/src/config.rs
@@ -1,6 +1,14 @@
+use std::path::Path;
+
 use axum::http::HeaderValue;
 use thiserror::Error;
 use webauthn_rs::prelude::Url;
+
+// All .env files live in the monorepo root, resolved at compile time. That is
+// safe because deployments supply real environment variables and missing files
+// are skipped silently.
+const MONOREPO_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
+const DEFAULT_NODE_ENV: &str = "development";
 
 const DEFAULT_PORT: u16 = 3000;
 const DEFAULT_RP_ID: &str = "localhost";
@@ -72,6 +80,32 @@ impl Config {
     }
 }
 
+/// Loads the monorepo root .env files following the dotenv-flow convention.
+///
+/// Real environment variables always win: `dotenvy::from_filename` never
+/// overrides an already-set variable, so visiting the candidates in
+/// highest-priority-first order reproduces dotenv-flow precedence.
+pub fn load_env_files() {
+    let node_env = std::env::var("NODE_ENV").unwrap_or_else(|_| DEFAULT_NODE_ENV.to_string());
+    let root = Path::new(MONOREPO_ROOT);
+
+    for file_name in env_file_names(&node_env) {
+        dotenvy::from_filename(root.join(file_name)).ok();
+    }
+}
+
+fn env_file_names(node_env: &str) -> Vec<String> {
+    let mut names = vec![format!(".env.{node_env}.local"), format!(".env.{node_env}")];
+
+    // dotenv-flow quirk: .env.local is not loaded for the test environment.
+    if node_env != "test" {
+        names.push(".env.local".to_string());
+    }
+
+    names.push(".env".to_string());
+    names
+}
+
 fn env_value(name: &'static str) -> Result<Option<String>, ConfigError> {
     match std::env::var(name) {
         Ok(value) => Ok(Some(value)),
@@ -95,6 +129,27 @@ fn parse_cors_origins(value: &str) -> Result<Vec<HeaderValue>, ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lists_env_files_in_priority_order() {
+        assert_eq!(
+            env_file_names("development"),
+            [
+                ".env.development.local",
+                ".env.development",
+                ".env.local",
+                ".env",
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_env_local_for_the_test_environment() {
+        assert_eq!(
+            env_file_names("test"),
+            [".env.test.local", ".env.test", ".env"]
+        );
+    }
 
     #[test]
     fn defaults_when_no_values_are_set() {

--- a/apps/cas/src/config.rs
+++ b/apps/cas/src/config.rs
@@ -8,7 +8,7 @@ use webauthn_rs::prelude::Url;
 // safe because deployments supply real environment variables and missing files
 // are skipped silently.
 const MONOREPO_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
-const DEFAULT_NODE_ENV: &str = "development";
+const DEFAULT_APP_ENV: &str = "development";
 
 const DEFAULT_PORT: u16 = 3000;
 const DEFAULT_RP_ID: &str = "localhost";
@@ -80,30 +80,28 @@ impl Config {
     }
 }
 
-/// Loads the monorepo root .env files following the dotenv-flow convention.
+/// Loads the monorepo root .env files. `APP_ENV` selects the environment
+/// (default: development).
 ///
 /// Real environment variables always win: `dotenvy::from_filename` never
 /// overrides an already-set variable, so visiting the candidates in
 /// highest-priority-first order reproduces dotenv-flow precedence.
 pub fn load_env_files() {
-    let node_env = std::env::var("NODE_ENV").unwrap_or_else(|_| DEFAULT_NODE_ENV.to_string());
+    let app_env = std::env::var("APP_ENV").unwrap_or_else(|_| DEFAULT_APP_ENV.to_string());
     let root = Path::new(MONOREPO_ROOT);
 
-    for file_name in env_file_names(&node_env) {
+    for file_name in env_file_names(&app_env) {
         dotenvy::from_filename(root.join(file_name)).ok();
     }
 }
 
-fn env_file_names(node_env: &str) -> Vec<String> {
-    let mut names = vec![format!(".env.{node_env}.local"), format!(".env.{node_env}")];
-
-    // dotenv-flow quirk: .env.local is not loaded for the test environment.
-    if node_env != "test" {
-        names.push(".env.local".to_string());
-    }
-
-    names.push(".env".to_string());
-    names
+fn env_file_names(app_env: &str) -> Vec<String> {
+    vec![
+        format!(".env.{app_env}.local"),
+        format!(".env.{app_env}"),
+        ".env.local".to_string(),
+        ".env".to_string(),
+    ]
 }
 
 fn env_value(name: &'static str) -> Result<Option<String>, ConfigError> {
@@ -144,10 +142,10 @@ mod tests {
     }
 
     #[test]
-    fn skips_env_local_for_the_test_environment() {
+    fn loads_env_local_for_every_environment() {
         assert_eq!(
             env_file_names("test"),
-            [".env.test.local", ".env.test", ".env"]
+            [".env.test.local", ".env.test", ".env.local", ".env"]
         );
     }
 

--- a/apps/cas/src/config.rs
+++ b/apps/cas/src/config.rs
@@ -1,0 +1,164 @@
+use axum::http::HeaderValue;
+use thiserror::Error;
+use webauthn_rs::prelude::Url;
+
+const DEFAULT_PORT: u16 = 3000;
+const DEFAULT_RP_ID: &str = "localhost";
+const DEFAULT_ORIGIN: &str = "http://localhost:5173";
+const DEFAULT_CORS_ORIGINS: &str = "http://localhost:5173";
+
+#[derive(Debug, Error, miette::Diagnostic)]
+pub enum ConfigError {
+    #[error("{0} is not valid unicode")]
+    #[diagnostic(code(cas::config_error))]
+    NotUnicode(&'static str),
+
+    #[error("CAS_PORT: {0:?} is not a valid port number")]
+    #[diagnostic(code(cas::config_error))]
+    InvalidPort(String),
+
+    #[error("CAS_ORIGIN: {0:?} is not a valid origin URL")]
+    #[diagnostic(code(cas::config_error))]
+    InvalidOrigin(String),
+
+    #[error("CAS_CORS_ORIGINS: {0:?} is not a valid origin")]
+    #[diagnostic(code(cas::config_error))]
+    InvalidCorsOrigin(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub port: u16,
+    pub rp_id: String,
+    pub origin: Url,
+    pub cors_origins: Vec<HeaderValue>,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, ConfigError> {
+        Self::from_values(
+            env_value("CAS_PORT")?,
+            env_value("CAS_RP_ID")?,
+            env_value("CAS_ORIGIN")?,
+            env_value("CAS_CORS_ORIGINS")?,
+        )
+    }
+
+    fn from_values(
+        port: Option<String>,
+        rp_id: Option<String>,
+        origin: Option<String>,
+        cors_origins: Option<String>,
+    ) -> Result<Self, ConfigError> {
+        let port = match port {
+            Some(value) => value.parse().map_err(|_| ConfigError::InvalidPort(value))?,
+            None => DEFAULT_PORT,
+        };
+
+        let rp_id = rp_id.unwrap_or_else(|| DEFAULT_RP_ID.to_string());
+
+        let origin = origin.unwrap_or_else(|| DEFAULT_ORIGIN.to_string());
+        let origin = Url::parse(&origin).map_err(|_| ConfigError::InvalidOrigin(origin))?;
+
+        let cors_origins = cors_origins.unwrap_or_else(|| DEFAULT_CORS_ORIGINS.to_string());
+        let cors_origins = parse_cors_origins(&cors_origins)?;
+
+        Ok(Self {
+            port,
+            rp_id,
+            origin,
+            cors_origins,
+        })
+    }
+}
+
+fn env_value(name: &'static str) -> Result<Option<String>, ConfigError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(ConfigError::NotUnicode(name)),
+    }
+}
+
+fn parse_cors_origins(value: &str) -> Result<Vec<HeaderValue>, ConfigError> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|origin| !origin.is_empty())
+        .map(|origin| {
+            HeaderValue::from_str(origin)
+                .map_err(|_| ConfigError::InvalidCorsOrigin(origin.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_when_no_values_are_set() {
+        let config = Config::from_values(None, None, None, None).unwrap();
+
+        assert_eq!(config.port, 3000);
+        assert_eq!(config.rp_id, "localhost");
+        assert_eq!(config.origin.as_str(), "http://localhost:5173/");
+        assert_eq!(
+            config.cors_origins,
+            vec![HeaderValue::from_static("http://localhost:5173")]
+        );
+    }
+
+    #[test]
+    fn parses_provided_values() {
+        let config = Config::from_values(
+            Some("8080".to_string()),
+            Some("cas.example.com".to_string()),
+            Some("https://cas.example.com".to_string()),
+            Some("https://a.example.com, https://b.example.com".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.rp_id, "cas.example.com");
+        assert_eq!(config.origin.as_str(), "https://cas.example.com/");
+        assert_eq!(
+            config.cors_origins,
+            vec![
+                HeaderValue::from_static("https://a.example.com"),
+                HeaderValue::from_static("https://b.example.com"),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        let error =
+            Config::from_values(Some("not-a-port".to_string()), None, None, None).unwrap_err();
+
+        assert!(matches!(error, ConfigError::InvalidPort(value) if value == "not-a-port"));
+    }
+
+    #[test]
+    fn rejects_invalid_origin() {
+        let error =
+            Config::from_values(None, None, Some("not-a-url".to_string()), None).unwrap_err();
+
+        assert!(matches!(error, ConfigError::InvalidOrigin(value) if value == "not-a-url"));
+    }
+
+    #[test]
+    fn rejects_invalid_cors_origin() {
+        let error = Config::from_values(
+            None,
+            None,
+            None,
+            Some("https://ok.example.com,bad\u{7f}origin".to_string()),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(error, ConfigError::InvalidCorsOrigin(value) if value == "bad\u{7f}origin")
+        );
+    }
+}

--- a/apps/cas/src/main.rs
+++ b/apps/cas/src/main.rs
@@ -12,7 +12,7 @@ use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use webauthn_rs::prelude::PasskeyRegistration;
 
-use crate::config::{Config, ConfigError};
+use crate::config::{Config, ConfigError, load_env_files};
 use crate::webauthn::{ApiState, UserId, router as webauthn_router};
 use std::net::Ipv4Addr;
 use std::{collections::HashMap, sync::Arc};
@@ -47,6 +47,8 @@ enum CasInitError {
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
+    load_env_files();
+
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
         .with(

--- a/apps/cas/src/main.rs
+++ b/apps/cas/src/main.rs
@@ -1,17 +1,20 @@
+mod config;
 mod webauthn;
 
-use axum::{Router, http::HeaderValue, routing::get};
+use axum::{Router, routing::get};
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
 use tower_http::{
-    cors::{Any, CorsLayer},
+    cors::{AllowOrigin, Any, CorsLayer},
     trace::{self, TraceLayer},
 };
 use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use webauthn_rs::prelude::{PasskeyRegistration, Url};
+use webauthn_rs::prelude::PasskeyRegistration;
 
+use crate::config::{Config, ConfigError};
 use crate::webauthn::{ApiState, UserId, router as webauthn_router};
+use std::net::Ipv4Addr;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -20,11 +23,19 @@ use tokio::sync::Mutex;
 enum CasError {
     #[error(transparent)]
     #[diagnostic(code(cas::io_error))]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
 
     #[error(transparent)]
     #[diagnostic(code(cas::init_error))]
-    InitError(#[from] CasInitError),
+    Init(#[from] CasInitError),
+
+    #[error(transparent)]
+    #[diagnostic(code(cas::config_error))]
+    Config(#[from] ConfigError),
+
+    #[error("Failed to configure WebAuthn: {0}")]
+    #[diagnostic(code(cas::webauthn_init_error))]
+    WebauthnInit(webauthn_rs::prelude::WebauthnError),
 }
 
 #[derive(Debug, Error, miette::Diagnostic)]
@@ -45,23 +56,25 @@ async fn main() -> miette::Result<()> {
         .try_init()
         .map_err(CasInitError::LoggerInitError)?;
 
-    let listener = TcpListener::bind("0.0.0.0:3000")
-        .await
-        .map_err(CasError::IoError)?;
+    let config = Config::from_env().map_err(CasError::Config)?;
 
-    let addr = listener.local_addr().map_err(CasError::IoError)?;
+    let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, config.port))
+        .await
+        .map_err(CasError::Io)?;
+
+    let addr = listener.local_addr().map_err(CasError::Io)?;
     tracing::info!("Server starting on http://{}", addr);
 
-    axum::serve(listener, app())
+    axum::serve(listener, app(config)?)
         .await
-        .map_err(CasError::IoError)?;
+        .map_err(CasError::Io)?;
 
     Ok(())
 }
 
-fn app() -> Router {
+fn app(config: Config) -> Result<Router, CasError> {
     let cors_layer = CorsLayer::new()
-        .allow_origin("http://localhost:5173".parse::<HeaderValue>().unwrap())
+        .allow_origin(AllowOrigin::list(config.cors_origins))
         .allow_methods(Any)
         .allow_headers(Any);
     let middleware_stack = ServiceBuilder::new()
@@ -75,23 +88,20 @@ fn app() -> Router {
         .layer(cors_layer);
 
     let registration_state = Arc::new(Mutex::new(HashMap::<UserId, PasskeyRegistration>::new()));
-    let webauthn = webauthn_rs::WebauthnBuilder::new(
-        "localhost",
-        &"http://localhost:5173".parse::<Url>().unwrap(),
-    )
-    .unwrap()
-    .build()
-    .unwrap();
+    let webauthn = webauthn_rs::WebauthnBuilder::new(&config.rp_id, &config.origin)
+        .map_err(CasError::WebauthnInit)?
+        .build()
+        .map_err(CasError::WebauthnInit)?;
 
     let api_state = ApiState {
         registration_state,
         webauthn,
     };
 
-    Router::new()
+    Ok(Router::new()
         .layer(middleware_stack)
         .route("/health", get(health_check))
-        .nest("/api/webauthn", webauthn_router(api_state))
+        .nest("/api/webauthn", webauthn_router(api_state)))
 }
 
 async fn health_check() -> &'static str {


### PR DESCRIPTION
Adds a `Config` struct loaded from environment at startup:

| Variable | Default |
| --- | --- |
| `CAS_PORT` | `3000` |
| `CAS_RP_ID` | `localhost` |
| `CAS_ORIGIN` | `http://localhost:5173` |
| `CAS_CORS_ORIGINS` | `http://localhost:5173` |

- Defaults keep `bacon run` working with no env set; any invalid value (unparseable port/URL/header) fails startup with a readable miette error.
- Hardcoded hosts/origins/rp_id and the `.unwrap()` calls in `app()` are gone — `app()` receives the parsed config and returns `Result`.
- Variables documented in `apps/cas/README.md`; unit tests cover defaults and invalid values.

## Loading `.env` files

`main()` now loads the monorepo root `.env` files via `dotenvy` before parsing the config (compare `apps/ligretto-gameplay-backend/src/config.ts`). `APP_ENV` selects the environment and defaults to `development`. Priority, highest first: the real process environment, `.env.{APP_ENV}.local`, `.env.{APP_ENV}`, `.env.local`, `.env`. Since `dotenvy::from_filename` never overrides an already-set variable, walking the candidates in that order yields exactly this precedence; missing files are skipped silently. The root is resolved from `CARGO_MANIFEST_DIR` at compile time, which is fine because deployments supply real environment variables and absent files are a no-op.

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)

