### PR TITLE
feat(cas): render extractor rejections in the ApiError format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -145,6 +146,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/apps/cas/Cargo.toml
+++ b/apps/cas/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 name = "cas"
 
 [dependencies]
-axum = "0.8.9"
+axum = { version = "0.8.9", features = ["macros"] }
 dotenvy = "0.15.7"
 miette = "7.6.0"
 serde = { version = "1.0.229", features = ["derive"] }

--- a/apps/cas/src/error.rs
+++ b/apps/cas/src/error.rs
@@ -1,5 +1,6 @@
 use axum::{
     Json,
+    extract::rejection::JsonRejection,
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -45,6 +46,19 @@ impl ApiError {
             code: "internal_error",
             message: "Internal server error".to_owned(),
             source: Some(source.into()),
+        }
+    }
+}
+
+/// Renders `Json` extractor rejections (malformed body, wrong content-type)
+/// in the standard error shape, keeping the rejection's status and message.
+impl From<JsonRejection> for ApiError {
+    fn from(rejection: JsonRejection) -> Self {
+        Self {
+            status: rejection.status(),
+            code: "invalid_body",
+            message: rejection.body_text(),
+            source: None,
         }
     }
 }

--- a/apps/cas/src/extract.rs
+++ b/apps/cas/src/extract.rs
@@ -1,0 +1,10 @@
+use axum::extract::FromRequest;
+
+use crate::error::ApiError;
+
+/// JSON body extractor whose rejections render as [`ApiError`] instead of
+/// axum's plain-text responses. Use for request bodies; responses can keep
+/// using `axum::Json`.
+#[derive(FromRequest)]
+#[from_request(via(axum::Json), rejection(ApiError))]
+pub struct Json<T>(pub T);

--- a/apps/cas/src/main.rs
+++ b/apps/cas/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod error;
+mod extract;
 mod webauthn;
 
 use axum::{

--- a/apps/cas/src/webauthn.rs
+++ b/apps/cas/src/webauthn.rs
@@ -11,6 +11,7 @@ use webauthn_rs::prelude::{
 };
 
 use crate::error::ApiError;
+use crate::extract::Json as AppJson;
 
 #[derive(Debug, Error, miette::Diagnostic)]
 pub enum RegistrationError {
@@ -104,7 +105,7 @@ async fn get_registration_options(
 
 async fn verify_registration(
     State(state): State<ApiState>,
-    Json(data): Json<VerifyRegistrationData>,
+    AppJson(data): AppJson<VerifyRegistrationData>,
 ) -> Result<Json<VerifyRegistrationResponse>, ApiError> {
     let user_id =
         Uuid::parse_str(&data.registration_id).map_err(RegistrationError::InvalidRegistrationId)?;
@@ -185,6 +186,40 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = error_body(response).await;
         assert_eq!(body["error"]["code"], "invalid_registration_id");
+        assert!(body["error"]["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn verify_registration_with_malformed_json_body_returns_api_error() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/verify-registration")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{not json"))
+            .unwrap();
+
+        let response = test_app().oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = error_body(response).await;
+        assert_eq!(body["error"]["code"], "invalid_body");
+        assert!(body["error"]["message"].is_string());
+    }
+
+    #[tokio::test]
+    async fn verify_registration_with_wrong_content_type_returns_api_error() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/verify-registration")
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from("{}"))
+            .unwrap();
+
+        let response = test_app().oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        let body = error_body(response).await;
+        assert_eq!(body["error"]["code"], "invalid_body");
         assert!(body["error"]["message"].is_string());
     }
 


### PR DESCRIPTION
JSON body rejections from axum's `Json` extractor were answered in axum's plain-text format instead of the `{"error": {"code", "message"}}` contract.

- New `extract::Json<T>` wrapper (`#[from_request(via(axum::Json), rejection(ApiError))]`) used by handlers for request bodies; responses keep `axum::Json`.
- `From<JsonRejection> for ApiError` preserves the rejection's status (400/415/422) and message under the stable code `invalid_body`.
- Tests: malformed JSON body and wrong content-type both render the ApiError shape.

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)