### PR TITLE
feat(cas): migrations infrastructure with cas-migrate

### DIFF
--- a/.github/workflows/cas-pr.yml
+++ b/.github/workflows/cas-pr.yml
@@ -40,6 +40,19 @@ jobs:
         working-directory: apps/cas
         run: cargo test
 
+  migration-order:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          # The check compares against origin/master, so it needs full history.
+          fetch-depth: 0
+
+      - name: Check migration timestamp order
+        run: apps/cas/scripts/check-migration-order.sh
+
   clippy:
     runs-on: ubuntu-24.04
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,4 +14,3 @@ From the repo root:
 ## Conventions
 
 - Code comments and agent docs — English only.
-- cas database migration workflow — described in `apps/cas/docs/MIGRATIONS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ From the repo root:
 ## Conventions
 
 - Code comments and agent docs — English only.
+- cas database migration workflow — described in `apps/cas/docs/MIGRATIONS.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,9 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -553,6 +556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +611,17 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-intrusive"
@@ -1011,6 +1036,16 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "litemap"
@@ -1565,6 +1600,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,7 +1705,9 @@ checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
@@ -1721,8 +1778,35 @@ dependencies = [
  "sqlx-core",
  "sqlx-postgres",
  "syn 2.0.119",
+ "thiserror 2.0.20",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror 2.0.20",
+ "tracing",
 ]
 
 [[package]]
@@ -1758,6 +1842,30 @@ dependencies = [
  "thiserror 2.0.20",
  "tracing",
  "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "flume",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror 2.0.20",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/apps/cas/AGENTS.md
+++ b/apps/cas/AGENTS.md
@@ -1,5 +1,6 @@
 # cas
 
-Rust (axum) authentication service. Database migration workflow (sqlx,
-`cas-migrate`, immutability, expand/contract) is described in
+Rust (axum) authentication service.
+
+Database migration workflow (sqlx, `cas-migrate`, immutability, expand/contract) is described in
 [docs/MIGRATIONS.md](./docs/MIGRATIONS.md).

--- a/apps/cas/AGENTS.md
+++ b/apps/cas/AGENTS.md
@@ -1,0 +1,5 @@
+# cas
+
+Rust (axum) authentication service. Database migration workflow (sqlx,
+`cas-migrate`, immutability, expand/contract) is described in
+[docs/MIGRATIONS.md](./docs/MIGRATIONS.md).

--- a/apps/cas/Cargo.toml
+++ b/apps/cas/Cargo.toml
@@ -6,13 +6,17 @@ edition = "2024"
 [[bin]]
 name = "cas"
 
+[[bin]]
+name = "cas-migrate"
+path = "src/bin/migrate.rs"
+
 [dependencies]
 axum = { version = "0.8.9", features = ["macros"] }
 dotenvy = "0.15.7"
 miette = "7.6.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "migrate"] }
 thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["full"] }
 tower = { version = "0.5.3", features = ["full"] }

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -32,6 +32,16 @@ docker compose -f apps/cas/docker-compose.yml up -d
 
 The connection pool is lazy: the server starts even when the DB is down. `GET /health` runs `SELECT 1` and returns `200` when the DB answers, `503` otherwise.
 
+## Migrations
+
+Migrations are applied by the `cas-migrate` binary, never by the app:
+
+```
+cargo run -p cas --bin cas-migrate
+```
+
+The workflow (creating migrations, immutability, expand/contract, CI ordering check) is described in [docs/MIGRATIONS.md](./docs/MIGRATIONS.md).
+
 ## Prepare bacon (used for dev server reload)
 
 ```

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -34,7 +34,7 @@ The connection pool is lazy: the server starts even when the DB is down. `GET /h
 
 ## Migrations
 
-Migrations are applied by the `cas-migrate` binary, never by the app:
+Migrations are applied by the `cas-migrate` binary:
 
 ```
 cargo run -p cas --bin cas-migrate

--- a/apps/cas/docs/MIGRATIONS.md
+++ b/apps/cas/docs/MIGRATIONS.md
@@ -1,0 +1,71 @@
+# Database migrations
+
+Migrations live in `apps/cas/migrations/` and are embedded into the binaries at
+compile time (`sqlx::migrate!` in `src/migrations.rs`). They are forward-only
+(no down files) with timestamp versions — the sqlx-cli default.
+
+Migrations are applied by the separate `cas-migrate` binary, **never by the
+app**: during a rollout, instances must keep serving on the previous schema.
+Later `cas-migrate` will run as a k8s job before deploys.
+
+## Tooling
+
+Creating a migration uses [sqlx-cli](https://crates.io/crates/sqlx-cli):
+
+```
+cargo install sqlx-cli --no-default-features --features rustls,postgres
+```
+
+```
+cd apps/cas
+sqlx migrate add <name>        # creates migrations/<timestamp>_<name>.sql
+```
+
+## Applying migrations
+
+```
+cargo run -p cas --bin cas-migrate
+```
+
+Reads `DATABASE_URL` exactly like the app (same `.env` handling, same default
+pointing at `docker-compose.yml`). Applies pending migrations and exits;
+a second run is a no-op. Exits non-zero on failure. sqlx takes an advisory
+lock, so concurrent runs are safe.
+
+The app never applies migrations, but dev builds check in the background on
+startup and log a warning listing pending migrations. A release build skips the
+check entirely; an unreachable DB only logs an info line.
+
+## Immutability
+
+An applied migration is recorded in `_sqlx_migrations` with a checksum, and
+`cas-migrate` fails if a file no longer matches. The rule kicks in when a
+migration is merged to master or applied to a shared database — from then on,
+fix mistakes with a **new** migration. A local WIP migration on your branch is
+freely editable; reset your dev DB after editing:
+
+```
+docker compose -f apps/cas/docker-compose.yml down -v && docker compose -f apps/cas/docker-compose.yml up -d
+cargo run -p cas --bin cas-migrate
+```
+
+(`sqlx database reset` does the same if you use sqlx-cli.)
+
+## Expand/contract
+
+Schema changes must keep the previous release working:
+
+1. **Expand** — additive migration (new table/column, nullable or defaulted).
+2. Deploy the code that uses it.
+3. **Contract** — a migration removing the old shape ships only after no
+   deployed code touches it.
+
+A rename is never a single `ALTER ... RENAME`: add the new column, backfill,
+switch the code, then drop the old column — spread across releases.
+
+## CI ordering check
+
+`apps/cas/scripts/check-migration-order.sh` (a `cas-pr.yml` job) fails a PR
+that adds a migration timestamped older than the newest one on master — sqlx
+would never apply it once a newer version is recorded. If it fires, recreate
+your migration with a fresh timestamp (`sqlx migrate add`).

--- a/apps/cas/migrations/20260830161752_baseline.sql
+++ b/apps/cas/migrations/20260830161752_baseline.sql
@@ -1,0 +1,3 @@
+-- Baseline no-op migration: proves the migrations pipeline end to end.
+-- The real schema starts with #664.
+SELECT 1;

--- a/apps/cas/scripts/check-migration-order.sh
+++ b/apps/cas/scripts/check-migration-order.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Fails when a migration added in this PR has a version not greater than the
+# newest migration already on master. Merging such a migration would leave it
+# permanently pending: sqlx never applies a migration older than one already
+# recorded in `_sqlx_migrations`.
+#
+# Usage: check-migration-order.sh [base-ref]   (default: origin/master)
+set -euo pipefail
+
+base_ref="${1:-origin/master}"
+migrations_dir="apps/cas/migrations"
+
+version_of() {
+  # 20260830161752_baseline.sql -> 20260830161752
+  local name
+  name="$(basename "$1")"
+  printf '%s\n' "${name%%_*}"
+}
+
+# Highest migration version already on the base branch.
+max_base=0
+while IFS= read -r file; do
+  version="$(version_of "$file")"
+  [[ "$version" =~ ^[0-9]+$ ]] || continue
+  if ((10#$version > max_base)); then
+    max_base=$((10#$version))
+  fi
+done < <(git ls-tree -r --name-only "$base_ref" -- "$migrations_dir")
+
+# Migrations added by this PR.
+added="$(git diff --name-only --diff-filter=A "$base_ref...HEAD" -- "$migrations_dir")"
+if [[ -z "$added" ]]; then
+  echo "No new migrations; nothing to check."
+  exit 0
+fi
+
+status=0
+while IFS= read -r file; do
+  version="$(version_of "$file")"
+  if ! [[ "$version" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: $file does not follow the <version>_<name>.sql naming convention."
+    status=1
+    continue
+  fi
+  if ((10#$version <= max_base)); then
+    echo "ERROR: $file has version $version <= $max_base (the newest migration on $base_ref)."
+    echo "       Recreate it with a fresh timestamp: sqlx migrate add <name>."
+    status=1
+  fi
+done <<<"$added"
+
+if ((status == 0)); then
+  echo "All new migrations are newer than $base_ref (max version $max_base)."
+fi
+exit "$status"

--- a/apps/cas/src/bin/migrate.rs
+++ b/apps/cas/src/bin/migrate.rs
@@ -1,0 +1,53 @@
+//! `cas-migrate` — applies pending database migrations and exits.
+//!
+//! Kept separate from the app on purpose: instances must keep serving on the
+//! previous schema during rollouts, so migrations run as their own step
+//! (later: a k8s job before deploys). sqlx takes an advisory lock, so
+//! concurrent runs are safe.
+
+use sqlx::Connection;
+use sqlx::postgres::PgConnection;
+use thiserror::Error;
+
+use cas::config::{Config, ConfigError, load_env_files};
+use cas::migrations::MIGRATOR;
+
+#[derive(Debug, Error, miette::Diagnostic)]
+enum MigrateError {
+    #[error(transparent)]
+    #[diagnostic(code(cas_migrate::config_error))]
+    Config(#[from] ConfigError),
+
+    #[error("Failed to connect to the database: {0}")]
+    #[diagnostic(
+        code(cas_migrate::connect_error),
+        help("is Postgres running and DATABASE_URL correct?")
+    )]
+    Connect(sqlx::Error),
+
+    #[error("Failed to apply migrations: {0}")]
+    #[diagnostic(code(cas_migrate::migrate_error))]
+    Migrate(sqlx::migrate::MigrateError),
+}
+
+#[tokio::main]
+async fn main() -> miette::Result<()> {
+    load_env_files();
+    let config = Config::from_env().map_err(MigrateError::Config)?;
+
+    // Eager connect: fail fast with a readable error instead of on first query.
+    let mut conn = PgConnection::connect(&config.database_url)
+        .await
+        .map_err(MigrateError::Connect)?;
+
+    MIGRATOR
+        .run(&mut conn)
+        .await
+        .map_err(MigrateError::Migrate)?;
+
+    println!(
+        "Migrations are up to date ({} embedded)",
+        MIGRATOR.iter().len()
+    );
+    Ok(())
+}

--- a/apps/cas/src/lib.rs
+++ b/apps/cas/src/lib.rs
@@ -1,0 +1,4 @@
+// Library part of the crate: modules shared between the `cas` server binary
+// and the `cas-migrate` binary.
+pub mod config;
+pub mod migrations;

--- a/apps/cas/src/main.rs
+++ b/apps/cas/src/main.rs
@@ -1,4 +1,3 @@
-mod config;
 mod error;
 mod extract;
 mod health;
@@ -21,9 +20,9 @@ use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use webauthn_rs::prelude::PasskeyRegistration;
 
-use crate::config::{Config, ConfigError, load_env_files};
 use crate::error::ApiError;
 use crate::webauthn::{ApiState, UserId, router as webauthn_router};
+use cas::config::{Config, ConfigError, load_env_files};
 use std::net::Ipv4Addr;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
@@ -80,6 +79,13 @@ async fn main() -> miette::Result<()> {
 
     let addr = listener.local_addr().map_err(CasError::Io)?;
     tracing::info!("Server starting on http://{}", addr);
+
+    // Dev-only: warn in the background when the DB is missing migrations.
+    // Never blocks or fails startup; compiled out of release builds.
+    #[cfg(debug_assertions)]
+    tokio::spawn(cas::migrations::warn_on_pending_migrations(
+        config.database_url.clone(),
+    ));
 
     axum::serve(listener, app(config)?)
         .await

--- a/apps/cas/src/migrations.rs
+++ b/apps/cas/src/migrations.rs
@@ -1,0 +1,43 @@
+use sqlx::migrate::Migrator;
+
+/// All migrations from `apps/cas/migrations/`, embedded at compile time.
+/// Applied by the `cas-migrate` binary only — the app never runs migrations.
+pub static MIGRATOR: Migrator = sqlx::migrate!();
+
+/// Dev-only startup check: warns when the DB is missing embedded migrations.
+/// Runs in a background task, never blocks or fails startup, and is compiled
+/// out of release builds.
+#[cfg(debug_assertions)]
+pub async fn warn_on_pending_migrations(database_url: String) {
+    use sqlx::Connection;
+    use std::collections::HashSet;
+
+    let mut conn = match sqlx::postgres::PgConnection::connect(&database_url).await {
+        Ok(conn) => conn,
+        Err(error) => {
+            tracing::info!(%error, "skipping the pending-migrations check: DB unreachable");
+            return;
+        }
+    };
+
+    // A missing `_sqlx_migrations` table means nothing was applied yet.
+    let applied: HashSet<i64> = sqlx::query_scalar("SELECT version FROM _sqlx_migrations")
+        .fetch_all(&mut conn)
+        .await
+        .map(HashSet::from_iter)
+        .unwrap_or_default();
+
+    let pending: Vec<String> = MIGRATOR
+        .iter()
+        .filter(|migration| !applied.contains(&migration.version))
+        .map(|migration| format!("{}_{}", migration.version, migration.description))
+        .collect();
+
+    if !pending.is_empty() {
+        tracing::warn!(
+            pending = ?pending,
+            "the database is missing {} migration(s); run cas-migrate",
+            pending.len()
+        );
+    }
+}


### PR DESCRIPTION
Sets up sqlx migrations infrastructure for cas. Migrations are applied by a separate `cas-migrate` binary, never by the app — instances keep serving on the previous schema during rollouts.

- `apps/cas/migrations/` embedded via `static MIGRATOR = sqlx::migrate!()` (new `migrations` module; `config` moved into a small lib so both binaries share it — `main.rs` behavior unchanged). One no-op baseline migration; the real schema starts with #664.
- `cas-migrate` (`src/bin/migrate.rs`): `load_env_files()` + `Config`, eager connect, `MIGRATOR.run()`, miette errors, non-zero exit on failure.
- Dev-only (`#[cfg(debug_assertions)]`) background startup check: warns with the list of pending migrations ("run cas-migrate"); DB unreachable → quiet info; never blocks startup; absent from release builds.
- CI: `scripts/check-migration-order.sh` (shellcheck-clean) fails a PR adding a migration timestamped older than the newest on master; new `migration-order` job in `cas-pr.yml` with `fetch-depth: 0`.
- Docs: `apps/cas/docs/MIGRATIONS.md` (tooling, immutability rule, dev reset loop, expand/contract, CI check), linked from `README.md`, new `apps/cas/AGENTS.md`, and the root `AGENTS.md`.

Verified manually against the dev Postgres: baseline applies, second run is a no-op, editing an applied migration fails with a checksum error, the app serves with and without the DB, a dev build logs the pending-migrations warning, and the ordering script fails an old-timestamped migration.

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)
