### PR TITLE
chore(ci): update GitHub Actions versions

### DIFF
--- a/.github/actions/deploy-helm/action.yml
+++ b/.github/actions/deploy-helm/action.yml
@@ -29,7 +29,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Install Helm
       shell: bash

--- a/.github/actions/prepare-nodejs/action.yml
+++ b/.github/actions/prepare-nodejs/action.yml
@@ -5,10 +5,10 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
 
     - name: Install node
-      uses: actions/setup-node@main
+      uses: actions/setup-node@v7
       with:
         node-version-file: 'package.json'
         cache: 'pnpm'

--- a/.github/workflows/blog-deploy.yml
+++ b/.github/workflows/blog-deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -52,5 +52,5 @@ jobs:
       url: https://blog.mems.fun
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v7
         name: Checkout

--- a/.github/workflows/blog-pr.yml
+++ b/.github/workflows/blog-pr.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js

--- a/.github/workflows/cas-pr.yml
+++ b/.github/workflows/cas-pr.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
         with:
           # The check compares against origin/master, so it needs full history.
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/fmt-lint-check-pr.yml
+++ b/.github/workflows/fmt-lint-check-pr.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js

--- a/.github/workflows/gamehub-deploy.yml
+++ b/.github/workflows/gamehub-deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -52,5 +52,5 @@ jobs:
       url: https://mems.fun
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v7
         name: Checkout

--- a/.github/workflows/gamehub-pr.yml
+++ b/.github/workflows/gamehub-pr.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js

--- a/.github/workflows/ligretto-deploy.yml
+++ b/.github/workflows/ligretto-deploy.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -119,7 +119,7 @@ jobs:
       name: Ligretto-production
       url: https://core.ligretto.app
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
       - name: Deploy
@@ -139,7 +139,7 @@ jobs:
       name: Ligretto-production
       url: https://api.ligretto.app
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
       - name: Deploy
@@ -161,12 +161,12 @@ jobs:
       url: https://ligretto.app
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v7
         name: Checkout
 
       - name: Download frontend dist
         id: download_frontend_dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: frontend-dist
           path: apps/ligretto-frontend/dist

--- a/.github/workflows/ligretto-pr.yml
+++ b/.github/workflows/ligretto-pr.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js

--- a/.github/workflows/ligretto-schedule-e2e.yml
+++ b/.github/workflows/ligretto-schedule-e2e.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/prepare-nodejs
         name: Prepare Node.js

--- a/.github/workflows/nodejs-update.yml
+++ b/.github/workflows/nodejs-update.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
 
       - name: Update pinned Node.js version
         id: update
@@ -36,13 +36,13 @@ jobs:
 
       - name: Install pnpm
         if: steps.update.outputs.updated == 'true'
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       # Reads the freshly bumped engines.node, so the lockfile is refreshed
       # with the very version this PR pins.
       - name: Install node
         if: steps.update.outputs.updated == 'true'
-        uses: actions/setup-node@main
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
@@ -56,7 +56,7 @@ jobs:
       - name: Create pull request
         id: pr
         if: steps.update.outputs.updated == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: 'chore/nodejs-${{ steps.update.outputs.target }}'
           commit-message: 'chore: update Node.js to ${{ steps.update.outputs.target }}'

--- a/.github/workflows/storybook-main.yml
+++ b/.github/workflows/storybook-main.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/storybook-pr.yml
+++ b/.github/workflows/storybook-pr.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
           CHROMATIC_SLUG: ${{ github.repository }}
 
       - name: Post Storybook link
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- storybook-pr-comment -->';


### PR DESCRIPTION
## Summary

- update GitHub-maintained actions to their latest stable major versions;
- update pnpm setup and pull-request automation actions to their latest stable major versions;
- replace moving `main` references with stable major tags across workflows and composite actions;
- retain `ubuntu-24.04`, which is already the latest stable Ubuntu runner used throughout the repository.

## Test plan

- `pnpm fmt:check` — passed
- `pnpm lint:check` — passed
- `pnpm ts-check` — passed
- `pnpm test:ci` — passed
- version-reference validation across `.github/**/*.yml` — passed
- `git diff --check` — passed

## Risk

Major action updates can change runtime behavior; CI will exercise the pull-request workflows before merge.

Fixes #681