### PR TITLE
feat(cas): accounts table and domain model (#664)

### DIFF
--- a/.github/workflows/cas-pr.yml
+++ b/.github/workflows/cas-pr.yml
@@ -29,6 +29,23 @@ jobs:
   test:
     runs-on: ubuntu-24.04
 
+    # Repository tests use `#[sqlx::test]`, which creates a throwaway database
+    # per test from DATABASE_URL and applies the migrations into it.
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: cas
+          POSTGRES_PASSWORD: cas
+          POSTGRES_DB: cas
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -40,6 +57,7 @@ jobs:
         working-directory: apps/cas
         env:
           SQLX_OFFLINE: 'true'
+          DATABASE_URL: postgres://cas:cas@localhost:5434/cas
         run: cargo test
 
   sqlx-cache:

--- a/.github/workflows/cas-pr.yml
+++ b/.github/workflows/cas-pr.yml
@@ -62,6 +62,8 @@ jobs:
 
   sqlx-cache:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -91,6 +93,8 @@ jobs:
           version: '1.21.1'
 
       - name: Install sqlx-cli
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           cargo binstall sqlx-cli@0.9.0
           --no-confirm
@@ -101,6 +105,7 @@ jobs:
         working-directory: apps/cas
         env:
           DATABASE_URL: postgres://cas:cas@localhost:5434/cas
+          SQLX_OFFLINE: 'true'
         run: cargo run --bin cas-migrate
 
       - name: Check SQLx query cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 2.0.20",
+ "time",
  "tokio",
  "tower",
  "tower-http",
@@ -1739,10 +1740,12 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.20",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots",
 ]
 
@@ -1776,7 +1779,9 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sqlx-core",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
  "syn 2.0.119",
  "thiserror 2.0.20",
  "tokio",
@@ -1806,7 +1811,9 @@ dependencies = [
  "sha2 0.11.0",
  "sqlx-core",
  "thiserror 2.0.20",
+ "time",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1840,7 +1847,9 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.20",
+ "time",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -1864,8 +1873,10 @@ dependencies = [
  "serde",
  "sqlx-core",
  "thiserror 2.0.20",
+ "time",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/cas/.sqlx/query-c20f863765d6dfc90da6c0ec48a40916c4db0f34d9cec776faa20074932b04e2.json
+++ b/apps/cas/.sqlx/query-c20f863765d6dfc90da6c0ec48a40916c4db0f34d9cec776faa20074932b04e2.json
@@ -1,0 +1,110 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO accounts (display_name, type, email)\n               VALUES ($1, $2, $3)\n               RETURNING\n                   id,\n                   display_name,\n                   type AS \"type: AccountType\",\n                   email,\n                   created_at,\n                   last_seen_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "display_name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "type: AccountType",
+        "type_info": {
+          "Custom": {
+            "name": "account_type",
+            "kind": {
+              "Enum": [
+                "guest",
+                "full"
+              ]
+            }
+          }
+        },
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "type"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "email",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "email"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "last_seen_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "last_seen_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "account_type",
+            "kind": {
+              "Enum": [
+                "guest",
+                "full"
+              ]
+            }
+          }
+        },
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "c20f863765d6dfc90da6c0ec48a40916c4db0f34d9cec776faa20074932b04e2"
+}

--- a/apps/cas/.sqlx/query-e20e02a538832ade3ae6e6c7ee418cdb0be74ce69cc1a377ee6158ef8e797ade.json
+++ b/apps/cas/.sqlx/query-e20e02a538832ade3ae6e6c7ee418cdb0be74ce69cc1a377ee6158ef8e797ade.json
@@ -1,0 +1,98 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                   id,\n                   display_name,\n                   type AS \"type: AccountType\",\n                   email,\n                   created_at,\n                   last_seen_at\n               FROM accounts\n               WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "display_name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "display_name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "type: AccountType",
+        "type_info": {
+          "Custom": {
+            "name": "account_type",
+            "kind": {
+              "Enum": [
+                "guest",
+                "full"
+              ]
+            }
+          }
+        },
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "type"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "email",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "email"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "last_seen_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "last_seen_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "e20e02a538832ade3ae6e6c7ee418cdb0be74ce69cc1a377ee6158ef8e797ade"
+}

--- a/apps/cas/AGENTS.md
+++ b/apps/cas/AGENTS.md
@@ -8,15 +8,5 @@ Database migration workflow (sqlx, `cas-migrate`, immutability, expand/contract)
 SQL query and offline cache workflow is described in
 [docs/QUERIES.md](./docs/QUERIES.md).
 
-## Tests
-
-```
-cd apps/cas
-docker compose up -d                                    # once, for the dev DB
-DATABASE_URL=postgres://cas:cas@localhost:5434/cas cargo test
-```
-
-Repository tests use `#[sqlx::test]`, which needs `DATABASE_URL` in the
-environment (it does not read the monorepo `.env` files the app uses). Each such
-test gets a throwaway database with the migrations applied, so tests never see
-each other's rows and no fixture teardown is needed.
+Test setup and the isolated SQLx database workflow are described in
+[docs/TESTS.md](./docs/TESTS.md).

--- a/apps/cas/AGENTS.md
+++ b/apps/cas/AGENTS.md
@@ -7,3 +7,16 @@ Database migration workflow (sqlx, `cas-migrate`, immutability, expand/contract)
 
 SQL query and offline cache workflow is described in
 [docs/QUERIES.md](./docs/QUERIES.md).
+
+## Tests
+
+```
+cd apps/cas
+docker compose up -d                                    # once, for the dev DB
+DATABASE_URL=postgres://cas:cas@localhost:5434/cas cargo test
+```
+
+Repository tests use `#[sqlx::test]`, which needs `DATABASE_URL` in the
+environment (it does not read the monorepo `.env` files the app uses). Each such
+test gets a throwaway database with the migrations applied, so tests never see
+each other's rows and no fixture teardown is needed.

--- a/apps/cas/Cargo.toml
+++ b/apps/cas/Cargo.toml
@@ -16,8 +16,9 @@ dotenvy = "0.15.7"
 miette = "7.6.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "migrate"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "migrate", "uuid", "time"] }
 thiserror = "2.0.20"
+time = "0.3.55"
 tokio = { version = "1.53.1", features = ["full"] }
 tower = { version = "0.5.3", features = ["full"] }
 tower-http = { version = "0.7.0", features = ["cors", "catch-panic", "full"] }

--- a/apps/cas/docs/TESTS.md
+++ b/apps/cas/docs/TESTS.md
@@ -1,0 +1,13 @@
+# Tests
+
+Start the development database once, then run the CAS test suite with an explicit database URL:
+
+```sh
+cd apps/cas
+docker compose up -d
+DATABASE_URL=postgres://cas:cas@localhost:5434/cas cargo test
+```
+
+Repository tests use `#[sqlx::test]`, which requires `DATABASE_URL` in the environment. It does not read the monorepo `.env` files used by the application.
+
+Each SQLx test receives a throwaway database with all migrations applied. Tests therefore do not share rows, and fixture teardown is unnecessary.

--- a/apps/cas/migrations/20260830195122_accounts.sql
+++ b/apps/cas/migrations/20260830195122_accounts.sql
@@ -1,0 +1,26 @@
+-- Accounts: the identity root. `id` is the OIDC `sub`.
+--
+-- Per docs/PLAN.md there is no unique username: `display_name` is non-unique
+-- and guests are regular rows (`type = 'guest'`) with no credentials, so one
+-- code path serves guests and full accounts.
+
+CREATE TYPE account_type AS ENUM ('guest', 'full');
+
+CREATE TABLE accounts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    display_name text NOT NULL,
+    type account_type NOT NULL,
+    -- Optional and unverified in v1: the future recovery anchor (M4).
+    -- Deliberately not unique yet; uniqueness needs verification to be
+    -- meaningful, and would let an unverified address block a real owner.
+    email text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    -- Drives guest GC (a cron delete of inactive guests) and "last seen" in the
+    -- dashboard. Starts equal to created_at.
+    last_seen_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Guest GC scans inactive guests; the partial index keeps full accounts out.
+CREATE INDEX accounts_guest_last_seen_at_idx
+    ON accounts (last_seen_at)
+    WHERE type = 'guest';

--- a/apps/cas/src/accounts.rs
+++ b/apps/cas/src/accounts.rs
@@ -1,0 +1,187 @@
+//! Accounts — the identity root of CAS.
+//!
+//! An account id is the OIDC `sub`. Guests are ordinary rows
+//! (`type = AccountType::Guest`) so sessions, `/me` and userinfo have a single
+//! code path for guests and full accounts; a guest that registers a passkey is
+//! upgraded in place, keeping its `sub`. See `docs/PLAN.md`.
+
+use sqlx::PgPool;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Whether an account has credentials of its own.
+///
+/// Maps to the Postgres `account_type` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+#[sqlx(type_name = "account_type", rename_all = "lowercase")]
+pub enum AccountType {
+    /// Temporary identity created without any user interaction.
+    Guest,
+    /// Account with at least one credential (a passkey).
+    Full,
+}
+
+/// A row of `accounts`.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct Account {
+    /// Stable account id, exposed as the OIDC `sub`.
+    pub id: Uuid,
+    /// Non-unique: CAS has no username in v1.
+    pub display_name: String,
+    pub r#type: AccountType,
+    /// Optional and unverified in v1; the future recovery anchor.
+    pub email: Option<String>,
+    pub created_at: OffsetDateTime,
+    /// Refreshed on activity; drives guest GC.
+    pub last_seen_at: OffsetDateTime,
+}
+
+/// The values a caller supplies when creating an account. `id`, `created_at`
+/// and `last_seen_at` are assigned by the database.
+#[derive(Debug, Clone)]
+pub struct NewAccount {
+    pub display_name: String,
+    pub r#type: AccountType,
+    pub email: Option<String>,
+}
+
+impl NewAccount {
+    /// A guest: no credentials, no email.
+    pub fn guest(display_name: impl Into<String>) -> Self {
+        Self {
+            display_name: display_name.into(),
+            r#type: AccountType::Guest,
+            email: None,
+        }
+    }
+
+    /// A full account. Email stays optional — registration only asks for a
+    /// display name.
+    pub fn full(display_name: impl Into<String>) -> Self {
+        Self {
+            display_name: display_name.into(),
+            r#type: AccountType::Full,
+            email: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+}
+
+/// Data access for `accounts`.
+#[derive(Debug, Clone)]
+pub struct AccountRepository {
+    pool: PgPool,
+}
+
+impl AccountRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Inserts an account and returns the stored row, including the
+    /// database-assigned id and timestamps.
+    pub async fn create(&self, account: NewAccount) -> Result<Account, sqlx::Error> {
+        sqlx::query_as!(
+            Account,
+            r#"INSERT INTO accounts (display_name, type, email)
+               VALUES ($1, $2, $3)
+               RETURNING
+                   id,
+                   display_name,
+                   type AS "type: AccountType",
+                   email,
+                   created_at,
+                   last_seen_at"#,
+            account.display_name,
+            account.r#type as AccountType,
+            account.email,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Looks an account up by id. `Ok(None)` means no such account.
+    pub async fn get(&self, id: Uuid) -> Result<Option<Account>, sqlx::Error> {
+        sqlx::query_as!(
+            Account,
+            r#"SELECT
+                   id,
+                   display_name,
+                   type AS "type: AccountType",
+                   email,
+                   created_at,
+                   last_seen_at
+               FROM accounts
+               WHERE id = $1"#,
+            id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[sqlx::test]
+    async fn creates_a_full_account_with_an_email(pool: PgPool) {
+        let repository = AccountRepository::new(pool);
+
+        let account = repository
+            .create(NewAccount::full("Ada").with_email("ada@example.com"))
+            .await
+            .unwrap();
+
+        assert_eq!(account.display_name, "Ada");
+        assert_eq!(account.r#type, AccountType::Full);
+        assert_eq!(account.email.as_deref(), Some("ada@example.com"));
+        // A fresh account has never been seen after its creation.
+        assert_eq!(account.last_seen_at, account.created_at);
+    }
+
+    #[sqlx::test]
+    async fn creates_a_guest_without_an_email(pool: PgPool) {
+        let repository = AccountRepository::new(pool);
+
+        let account = repository.create(NewAccount::guest("Guest")).await.unwrap();
+
+        assert_eq!(account.r#type, AccountType::Guest);
+        assert_eq!(account.email, None);
+    }
+
+    #[sqlx::test]
+    async fn get_returns_the_created_account(pool: PgPool) {
+        let repository = AccountRepository::new(pool);
+        let created = repository.create(NewAccount::full("Grace")).await.unwrap();
+
+        let found = repository.get(created.id).await.unwrap();
+
+        assert_eq!(found, Some(created));
+    }
+
+    #[sqlx::test]
+    async fn get_returns_none_for_an_unknown_id(pool: PgPool) {
+        let repository = AccountRepository::new(pool);
+
+        let found = repository.get(Uuid::new_v4()).await.unwrap();
+
+        assert_eq!(found, None);
+    }
+
+    /// v1 has no username: two accounts may share a display name.
+    #[sqlx::test]
+    async fn display_names_are_not_unique(pool: PgPool) {
+        let repository = AccountRepository::new(pool);
+
+        let first = repository.create(NewAccount::full("Ada")).await.unwrap();
+        let second = repository.create(NewAccount::full("Ada")).await.unwrap();
+
+        assert_ne!(first.id, second.id);
+    }
+}

--- a/apps/cas/src/lib.rs
+++ b/apps/cas/src/lib.rs
@@ -1,4 +1,5 @@
-// Library part of the crate: modules shared between the `cas` server binary
-// and the `cas-migrate` binary.
+// Library part of the crate: the domain and the modules shared between the
+// `cas` server binary and the `cas-migrate` binary.
+pub mod accounts;
 pub mod config;
 pub mod migrations;

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'oxfmt'
 
 export default defineConfig({
-  ignorePatterns: ['dist/', '**/chart/**/*.yaml', '**/.adonisjs/**', '.next', 'next-env.d.ts'],
+  ignorePatterns: ['dist/', '**/chart/**/*.yaml', '**/.adonisjs/**', '.next', 'next-env.d.ts', 'apps/cas/*', '!apps/cas/README.md'],
   singleQuote: true,
   arrowParens: 'avoid',
   semi: false,


### PR DESCRIPTION
Depends on #689.

Adds the `accounts` table — the identity root, whose `id` is the OIDC `sub` — plus the Rust domain type and a repository with create/get. No endpoints yet; #665 wires registration on top.

Per docs/PLAN.md there is no unique username (`display_name` is non-unique) and guests are regular rows (`type = guest`), so guests and full accounts share one code path. `email` is nullable and unverified in v1; it is not unique yet because uniqueness without verification would let an unverified address block the real owner.

Repository queries use compile-time-checked SQLx macros and commit their offline cache. Tests use `#[sqlx::test]`, which gives each test a throwaway database with the migrations applied, so the CI test job runs against a Postgres service.