### PR TITLE
feat(cas): cookie sessions, /api/me and /api/logout (#667)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,12 +329,16 @@ name = "cas"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-extra",
+ "base64 0.22.1",
  "dotenvy",
+ "getrandom 0.4.3",
  "icu_properties",
  "miette",
  "nutype",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.20",
  "time",
@@ -385,12 +411,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -509,6 +552,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "digest"
@@ -527,6 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]

--- a/apps/cas/.sqlx/query-88ce597e1c22cc026cefd592621282dfe497fd49b3c6fad46ee083e0ab05e9e7.json
+++ b/apps/cas/.sqlx/query-88ce597e1c22cc026cefd592621282dfe497fd49b3c6fad46ee083e0ab05e9e7.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE accounts SET last_seen_at = now() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "88ce597e1c22cc026cefd592621282dfe497fd49b3c6fad46ee083e0ab05e9e7"
+}

--- a/apps/cas/.sqlx/query-b3d44a5b7f19cd4b66457c60ed8430208b533ff3d22388463c35319755016d38.json
+++ b/apps/cas/.sqlx/query-b3d44a5b7f19cd4b66457c60ed8430208b533ff3d22388463c35319755016d38.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, account_id, created_at, expires_at\n           FROM sessions\n           WHERE token_hash = $1 AND expires_at > now()",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "account_id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "account_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "expires_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "expires_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b3d44a5b7f19cd4b66457c60ed8430208b533ff3d22388463c35319755016d38"
+}

--- a/apps/cas/.sqlx/query-caa945a4aaf042077df739326d98dbe1df05fb24fa24c22d0ffbca394d7976b7.json
+++ b/apps/cas/.sqlx/query-caa945a4aaf042077df739326d98dbe1df05fb24fa24c22d0ffbca394d7976b7.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM sessions WHERE token_hash = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "caa945a4aaf042077df739326d98dbe1df05fb24fa24c22d0ffbca394d7976b7"
+}

--- a/apps/cas/.sqlx/query-fda75993d329970fc735b19d6557e74d1ced52e66e6a0c4d46b695cfcce3cfdd.json
+++ b/apps/cas/.sqlx/query-fda75993d329970fc735b19d6557e74d1ced52e66e6a0c4d46b695cfcce3cfdd.json
@@ -1,0 +1,66 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO sessions (account_id, token_hash, expires_at)\n           VALUES ($1, $2, now() + make_interval(secs => $3))\n           RETURNING id, account_id, created_at, expires_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "account_id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "account_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "expires_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "expires_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bytea",
+        "Float8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fda75993d329970fc735b19d6557e74d1ced52e66e6a0c4d46b695cfcce3cfdd"
+}

--- a/apps/cas/Cargo.toml
+++ b/apps/cas/Cargo.toml
@@ -12,15 +12,19 @@ path = "src/bin/migrate.rs"
 
 [dependencies]
 axum = { version = "0.8.9", features = ["macros"] }
+axum-extra = { version = "0.12.6", features = ["cookie"] }
+base64 = "0.22.1"
 dotenvy = "0.15.7"
+getrandom = "0.4.3"
 icu_properties = "2.3"
 miette = "7.6.0"
 nutype = { version = "0.7.0", features = ["serde"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+sha2 = "0.11.0"
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "migrate", "uuid", "time", "json"] }
 thiserror = "2.0.20"
-time = "0.3.55"
+time = { version = "0.3.55", features = ["serde-well-known"] }
 tokio = { version = "1.53.1", features = ["full"] }
 tower = { version = "0.5.3", features = ["full"] }
 tower-http = { version = "0.7.0", features = ["cors", "catch-panic", "full"] }

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -10,7 +10,7 @@ Configuration is read from environment variables at startup. Every variable has 
 | ------------------ | --------------------------------------- | ------------------------------------------------------------------ |
 | `CAS_PORT`         | `3000`                                  | TCP port the server listens on.                                    |
 | `CAS_RP_ID`        | `localhost`                             | WebAuthn relying party ID.                                         |
-| `CAS_ORIGIN`       | `http://localhost:5173`                 | WebAuthn relying party origin URL.                                 |
+| `CAS_ORIGIN`       | `http://localhost:5173`                 | WebAuthn relying party origin URL. An `https` origin also marks the session cookie `Secure`. |
 | `CAS_CORS_ORIGINS` | `http://localhost:5173`                 | Comma-separated list of allowed CORS origins.                      |
 | `DATABASE_URL`     | `postgres://cas:cas@localhost:5434/cas` | Postgres connection URL. The default matches `docker-compose.yml`. |
 

--- a/apps/cas/README.md
+++ b/apps/cas/README.md
@@ -6,13 +6,13 @@ CAS (Central Authentication Service) is a centralized authentication and user ma
 
 Configuration is read from environment variables at startup. Every variable has a dev-friendly default, so `bacon run` works with no environment set. An invalid value fails startup with an error.
 
-| Variable           | Default                                 | Description                                                        |
-| ------------------ | --------------------------------------- | ------------------------------------------------------------------ |
-| `CAS_PORT`         | `3000`                                  | TCP port the server listens on.                                    |
-| `CAS_RP_ID`        | `localhost`                             | WebAuthn relying party ID.                                         |
+| Variable           | Default                                 | Description                                                                                  |
+| ------------------ | --------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `CAS_PORT`         | `3000`                                  | TCP port the server listens on.                                                              |
+| `CAS_RP_ID`        | `localhost`                             | WebAuthn relying party ID.                                                                   |
 | `CAS_ORIGIN`       | `http://localhost:5173`                 | WebAuthn relying party origin URL. An `https` origin also marks the session cookie `Secure`. |
-| `CAS_CORS_ORIGINS` | `http://localhost:5173`                 | Comma-separated list of allowed CORS origins.                      |
-| `DATABASE_URL`     | `postgres://cas:cas@localhost:5434/cas` | Postgres connection URL. The default matches `docker-compose.yml`. |
+| `CAS_CORS_ORIGINS` | `http://localhost:5173`                 | Comma-separated list of allowed CORS origins.                                                |
+| `DATABASE_URL`     | `postgres://cas:cas@localhost:5434/cas` | Postgres connection URL. The default matches `docker-compose.yml`.                           |
 
 At startup the service also loads the monorepo root `.env` files. `APP_ENV` selects the environment and defaults to `development`; missing files are skipped. Priority, highest first:
 

--- a/apps/cas/docs/MIGRATIONS.md
+++ b/apps/cas/docs/MIGRATIONS.md
@@ -36,6 +36,18 @@ The app never applies migrations, but dev builds check in the background on
 startup and log a warning listing pending migrations. A release build skips the
 check entirely; an unreachable DB only logs an info line.
 
+One case needs sqlx-cli instead: a branch that adds a table *and* the first
+queries against it. `cas-migrate` shares the crate with those queries, and
+with `DATABASE_URL` set the query macros check them against the database at
+compile time — before the migration that creates the table has run. Apply the
+migration without compiling the crate, then refresh the cache:
+
+```
+cd apps/cas
+sqlx migrate run
+cargo sqlx prepare
+```
+
 ## Immutability
 
 An applied migration is recorded in `_sqlx_migrations` with a checksum, and

--- a/apps/cas/docs/PLAN.md
+++ b/apps/cas/docs/PLAN.md
@@ -147,9 +147,9 @@ dashboard [#671](https://github.com/MemeBattle/monorepo/issues/671).
 - [ ] Generate an OpenAPI description of the HTTP API, including error responses
       and their codes (e.g. utoipa), instead of maintaining a hand-written
       catalogue.
-- [ ] Expired `webauthn_ceremonies` rows are not removed by the application
-      (ADR 0002): add a periodic cleanup (k8s CronJob running the DELETE, or
-      pg_cron) before launch.
+- [ ] Expired `webauthn_ceremonies` and `sessions` rows are not removed by the
+      application (ADR 0002, ADR 0004): add a periodic cleanup (k8s CronJob
+      running the DELETE, or pg_cron) before launch.
 
 ## Working agreements (lit factory)
 

--- a/apps/cas/docs/adr/0004-cookie-sessions.md
+++ b/apps/cas/docs/adr/0004-cookie-sessions.md
@@ -1,0 +1,90 @@
+# 4. Cookie sessions
+
+## Status
+
+Accepted (2026-09-12), with [#667](https://github.com/MemeBattle/monorepo/issues/667).
+
+## Context
+
+Registration (ADR 0001) and login (ADR 0003) prove who a browser is at one
+moment. Something has to carry that proof to the next request: the dashboard,
+passkey management (#668), and later the OIDC `/authorize` endpoint, which
+must know who is asking before it can issue a code to a client.
+
+CAS runs as several replicas (ADR 0002), so whatever a session is, it cannot
+live in a process. The frontend is served from a different origin in
+development and must be able to call the API with the session attached.
+
+## Decision
+
+**(a) Server-side sessions, referenced by a random token in a cookie.** A
+session is a row in `sessions`; the cookie holds 256 random bits, base64url
+encoded. No signed or encrypted cookie: a row can be revoked, listed and
+expired by the server, and an opaque token reveals nothing if the cookie is
+ever read.
+
+**(b) The row stores the SHA-256 of the token, never the token.** A read of
+the table, in a backup or over the shoulder in `psql`, does not hand out live
+sessions. Lookup is by the hash, which is the unique column. The token exists
+in memory only between its generation and the response that sets the cookie.
+
+**(c) Expiry is absolute, 30 days, measured by the database clock.** The
+cookie's `Max-Age` and the row's `expires_at` are derived from the same
+constant, so the browser and the server give up together. A sliding expiry
+would cost a write on every authenticated request; it can be added when a
+product need appears. Expired rows are not returned and are not removed by
+the application: like `webauthn_ceremonies`, cleanup is a scheduled job, never
+part of the request path.
+
+**(d) The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, host-only, and
+`Secure` when the relying party origin is https.** `HttpOnly`: script never
+reads it. `Lax` rather than `Strict`: the future `/authorize` redirect is a
+top-level navigation from another site and must carry the cookie; `Lax` still
+withholds it from cross-site POSTs, which is the CSRF line. `Secure` follows
+the scheme of `CAS_ORIGIN` because Safari refuses a `Secure` cookie over plain
+http even from localhost, and the development origin is plain http.
+
+**(e) CORS allows credentials, and therefore lists methods and headers.**
+The frontend calls the API cross-origin in development with
+`credentials: 'include'`. Browsers refuse `Access-Control-Allow-Credentials`
+next to a wildcard, so the allowed methods and headers are enumerated. The
+JSON content type forces a preflight on every state-changing request, which
+together with `SameSite=Lax` is the CSRF posture for v1. A dedicated CSRF
+token is not needed while every mutating endpoint takes JSON.
+
+**(f) Registration and login sign the account in.** Their finish handlers
+create a session and set the cookie in the same response. The session is
+written after the ceremony's transaction commits: a failed session write after
+a successful login is a 503 the client retries by signing in again, and the
+recorded credential use is not undone. Session creation also moves the
+account's `last_seen_at`, in the session's own transaction: signing in is the
+activity guest GC will look for.
+
+**(g) One 401 code, `unauthenticated`, for every way a request fails to
+carry a session** — no cookie, a malformed one, an unknown, expired or
+revoked session. The client's remedy is the same in every case, and a probe
+learns nothing about which sessions exist. `POST /api/logout` is the
+exception: it is idempotent and never a 401. A browser holding a stale cookie
+is asking to forget it, and the answer to that is yes; the cookie is cleared
+whether or not a row was found.
+
+**(h) `Authenticated` is an axum extractor.** A handler that takes one runs
+only for a request with a live session and receives the session and the
+account; the 401 happens before the handler. It lives in the sessions
+context's transport and is the one thing other contexts import from it.
+
+## Consequences
+
+- `GET /api/me` answers with the account (id, display name, type, email) and
+  the session's expiry, nothing else about the session.
+- A session outlives a passkey: deleting a credential (#668) does not end the
+  sessions that were opened with it. Ending them is an explicit act, and a
+  "sign out everywhere" belongs with session listing, later.
+- Every authenticated request costs two reads: the session by hash, then the
+  account by id. A join would save one round trip and put another context's
+  columns in this context's SQL; the round trip is the cheaper price.
+- The `sessions` table grows by one row per sign-in and per expired session
+  until the scheduled cleanup exists; the index on `expires_at` is there for
+  it.
+- The session id is the row's identity for the future management screen; the
+  token never identifies a session anywhere but in the lookup.

--- a/apps/cas/docs/adr/0004-cookie-sessions.md
+++ b/apps/cas/docs/adr/0004-cookie-sessions.md
@@ -36,6 +36,12 @@ product need appears. Expired rows are not returned and are not removed by
 the application: like `webauthn_ceremonies`, cleanup is a scheduled job, never
 part of the request path.
 
+This is longer than the OWASP Session Management guidance (an idle timeout on
+top of an absolute one, and a non-persistent cookie). Whether a game SSO
+justifies it is decided in
+[#697](https://github.com/MemeBattle/monorepo/issues/697); this ADR is amended
+with the outcome.
+
 **(d) The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, host-only, and
 `Secure` when the relying party origin is https.** `HttpOnly`: script never
 reads it. `Lax` rather than `Strict`: the future `/authorize` redirect is a
@@ -48,9 +54,15 @@ http even from localhost, and the development origin is plain http.
 The frontend calls the API cross-origin in development with
 `credentials: 'include'`. Browsers refuse `Access-Control-Allow-Credentials`
 next to a wildcard, so the allowed methods and headers are enumerated. The
-JSON content type forces a preflight on every state-changing request, which
-together with `SameSite=Lax` is the CSRF posture for v1. A dedicated CSRF
-token is not needed while every mutating endpoint takes JSON.
+JSON content type forces a preflight on every state-changing request that
+carries a body, which together with `SameSite=Lax` is the CSRF posture of this
+change. It has one known gap: `POST /api/logout` takes no body, so a cross-site
+HTML form can reach it and only `SameSite=Lax` stands in the way. OWASP counts
+`SameSite` as defence in depth, not as a defence on its own. The exposure is a
+forced sign-out, nothing more, and it is closed by a Fetch Metadata / `Origin`
+check on every mutating request in
+[#696](https://github.com/MemeBattle/monorepo/issues/696), which also covers
+body-less endpoints to come (passkey delete, #668).
 
 **(f) Registration and login sign the account in.** Their finish handlers
 create a session and set the cookie in the same response. The session is
@@ -88,3 +100,11 @@ context's transport and is the one thing other contexts import from it.
   it.
 - The session id is the row's identity for the future management screen; the
   token never identifies a session anywhere but in the lookup.
+- Hardening that OWASP recommends and this change leaves out is tracked
+  separately: the CSRF layer ([#696](https://github.com/MemeBattle/monorepo/issues/696)),
+  the timeout decision ([#697](https://github.com/MemeBattle/monorepo/issues/697)),
+  `Cache-Control: no-store` and `Clear-Site-Data`
+  ([#698](https://github.com/MemeBattle/monorepo/issues/698)), session
+  lifecycle logging ([#699](https://github.com/MemeBattle/monorepo/issues/699))
+  and the `__Host-` cookie prefix
+  ([#700](https://github.com/MemeBattle/monorepo/issues/700)).

--- a/apps/cas/migrations/20260912133851_sessions.sql
+++ b/apps/cas/migrations/20260912133851_sessions.sql
@@ -1,0 +1,24 @@
+-- Server-side sessions: what a signed-in browser holds between requests.
+--
+-- The browser keeps a random token in an HttpOnly cookie; the row keeps only
+-- the SHA-256 of that token, so a read of this table does not hand out live
+-- sessions. Lookup is by the hash, which is why it is the unique column.
+-- See docs/adr/0004-cookie-sessions.md.
+
+CREATE TABLE sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id uuid NOT NULL REFERENCES accounts (id) ON DELETE CASCADE,
+    token_hash bytea NOT NULL UNIQUE,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    -- Absolute lifetime, fixed when the session is created. A request after
+    -- this point is unauthenticated; the application never removes rows past
+    -- it, a separate scheduled cleanup will (as for webauthn_ceremonies).
+    expires_at timestamptz NOT NULL
+);
+
+-- Listing an account's sessions and the ON DELETE CASCADE above both look
+-- rows up by account_id.
+CREATE INDEX sessions_account_id_idx ON sessions (account_id);
+
+-- For the scheduled cleanup of expired rows.
+CREATE INDEX sessions_expires_at_idx ON sessions (expires_at);

--- a/apps/cas/src/accounts/mod.rs
+++ b/apps/cas/src/accounts/mod.rs
@@ -13,13 +13,15 @@ use uuid::Uuid;
 
 pub use display_name::{DisplayName, DisplayNameError, MAX_DISPLAY_NAME_LENGTH};
 pub use repository::AccountRepository;
-pub(crate) use repository::{get, insert};
+pub(crate) use repository::{get, insert, touch_last_seen};
 
 /// Whether an account has credentials of its own.
 ///
-/// Maps to the Postgres `account_type` enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
+/// Maps to the Postgres `account_type` enum; on the wire it is the same
+/// lowercase word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, serde::Serialize, serde::Deserialize)]
 #[sqlx(type_name = "account_type", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum AccountType {
     /// Temporary identity created without any user interaction.
     Guest,

--- a/apps/cas/src/accounts/repository.rs
+++ b/apps/cas/src/accounts/repository.rs
@@ -95,6 +95,19 @@ where
     .await
 }
 
+/// Marks an account as active now. Session creation calls it inside its own
+/// transaction; guest GC will read what it writes.
+pub(crate) async fn touch_last_seen<'e, E>(executor: E, id: Uuid) -> Result<(), sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query!("UPDATE accounts SET last_seen_at = now() WHERE id = $1", id)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
 /// Data access for `accounts`.
 #[derive(Debug, Clone)]
 pub struct AccountRepository {

--- a/apps/cas/src/http/mod.rs
+++ b/apps/cas/src/http/mod.rs
@@ -8,7 +8,7 @@ mod health;
 
 use axum::{
     Router,
-    http::HeaderValue,
+    http::{HeaderValue, Method, header},
     response::{IntoResponse, Response},
 };
 use sqlx::postgres::PgPoolOptions;
@@ -16,13 +16,16 @@ use thiserror::Error;
 use tower::ServiceBuilder;
 use tower_http::{
     catch_panic::CatchPanicLayer,
-    cors::{AllowOrigin, Any, CorsLayer},
+    cors::{AllowOrigin, CorsLayer},
     trace::{self, TraceLayer},
 };
 use tracing::Level;
 
 use crate::config::Config;
 use crate::http::error::ApiError;
+use crate::sessions::SessionService;
+use crate::sessions::http as sessions_http;
+use crate::sessions::http::CookieSettings;
 use crate::webauthn::build_webauthn;
 use crate::webauthn::http as webauthn_http;
 use crate::webauthn::login::LoginService;
@@ -46,6 +49,8 @@ pub enum AppError {
 pub struct ApiState {
     pub registration: RegistrationService,
     pub login: LoginService,
+    pub sessions: SessionService,
+    pub cookies: CookieSettings,
 }
 
 pub fn app(config: Config) -> Result<Router, AppError> {
@@ -61,11 +66,14 @@ pub fn app(config: Config) -> Result<Router, AppError> {
     let api_state = ApiState {
         registration: RegistrationService::new(webauthn.clone(), pool.clone()),
         login: LoginService::new(webauthn, pool.clone()),
+        sessions: SessionService::new(pool.clone()),
+        cookies: CookieSettings::for_origin(&config.origin),
     };
 
     let router = Router::new()
         .merge(health::router(pool))
-        .nest("/api/webauthn", webauthn_http::router(api_state));
+        .nest("/api/webauthn", webauthn_http::router(api_state.clone()))
+        .nest("/api", sessions_http::router(api_state));
 
     Ok(with_middleware(router, config.cors_origins))
 }
@@ -75,11 +83,22 @@ pub fn app(config: Config) -> Result<Router, AppError> {
 ///
 /// `CatchPanicLayer` sits innermost so a panic response still passes through
 /// the CORS and trace layers on the way out.
+///
+/// The session cookie travels cross-origin from the frontend, which needs
+/// `Access-Control-Allow-Credentials`; browsers refuse that next to a
+/// wildcard, so methods and headers are listed rather than `Any`.
 fn with_middleware(router: Router, cors_origins: Vec<HeaderValue>) -> Router {
     let cors_layer = CorsLayer::new()
         .allow_origin(AllowOrigin::list(cors_origins))
-        .allow_methods(Any)
-        .allow_headers(Any);
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+        ])
+        .allow_headers([header::CONTENT_TYPE])
+        .allow_credentials(true);
 
     router.layer(
         ServiceBuilder::new()
@@ -154,6 +173,46 @@ mod tests {
                 .headers()
                 .contains_key(header::ACCESS_CONTROL_ALLOW_METHODS)
         );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .expect("the session cookie needs credentials to be allowed"),
+            "true"
+        );
+    }
+
+    /// The sessions router is nested at `/api` and the webauthn one inside
+    /// that prefix; a request must reach the right one. Both requests fail
+    /// before any query, so no database is needed.
+    #[tokio::test]
+    async fn both_contexts_are_reachable_under_the_api_prefix() {
+        let app = app(test_config()).unwrap();
+
+        let me = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(me.status(), StatusCode::UNAUTHORIZED);
+
+        let login = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/webauthn/verify-login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"loginId":"not-a-uuid","response":{}}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(login.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]

--- a/apps/cas/src/lib.rs
+++ b/apps/cas/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod db;
 pub mod http;
 pub mod migrations;
+pub mod sessions;
 #[cfg(test)]
 pub(crate) mod testing;
 pub mod webauthn;

--- a/apps/cas/src/sessions/http/cookie.rs
+++ b/apps/cas/src/sessions/http/cookie.rs
@@ -1,0 +1,110 @@
+//! The session cookie: the one place its name and attributes are decided.
+
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use webauthn_rs::prelude::Url;
+
+use crate::sessions::{SESSION_LIFETIME, SessionToken};
+
+/// The cookie's name. The `cas_` prefix keeps it apart from anything another
+/// app on the same site might set.
+pub const SESSION_COOKIE: &str = "cas_session";
+
+/// What varies between deployments. Decided once at startup from the
+/// configuration and carried in the API state.
+#[derive(Debug, Clone, Copy)]
+pub struct CookieSettings {
+    /// `Secure` is set whenever the relying party origin is https. It is left
+    /// off for the plain-http development origin, because Safari does not
+    /// accept a `Secure` cookie over http even from localhost.
+    pub secure: bool,
+}
+
+impl CookieSettings {
+    pub fn for_origin(origin: &Url) -> Self {
+        Self {
+            secure: origin.scheme() == "https",
+        }
+    }
+
+    /// The cookie that carries a freshly issued session.
+    ///
+    /// `HttpOnly`: script never reads it. `SameSite=Lax`: sent on top-level
+    /// navigations (the future OIDC `/authorize` redirect must carry it) but
+    /// not on cross-site POSTs, which is the CSRF line. `Path=/`: one cookie
+    /// for the whole service. `Max-Age`: the same lifetime the row has.
+    pub fn session(&self, token: &SessionToken) -> Cookie<'static> {
+        let mut cookie = self.base(token.expose().to_owned());
+        cookie.set_max_age(
+            time::Duration::try_from(SESSION_LIFETIME)
+                .expect("the session lifetime fits in a cookie max-age"),
+        );
+        cookie
+    }
+
+    /// The cookie that removes the session cookie: same name, path and
+    /// flags, `Max-Age=0`. The attributes must match for the browser to
+    /// treat it as the same cookie.
+    pub fn removal(&self) -> Cookie<'static> {
+        let mut cookie = self.base(String::new());
+        cookie.set_max_age(time::Duration::ZERO);
+        cookie
+    }
+
+    fn base(&self, value: String) -> Cookie<'static> {
+        Cookie::build((SESSION_COOKIE, value))
+            .http_only(true)
+            .secure(self.secure)
+            .same_site(SameSite::Lax)
+            .path("/")
+            .build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn origin(value: &str) -> Url {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn secure_follows_the_origin_scheme() {
+        assert!(CookieSettings::for_origin(&origin("https://cas.example.com")).secure);
+        assert!(!CookieSettings::for_origin(&origin("http://localhost:5173")).secure);
+    }
+
+    #[test]
+    fn the_session_cookie_is_locked_down() {
+        let token = SessionToken::generate().unwrap();
+        let settings = CookieSettings { secure: true };
+
+        let cookie = settings.session(&token);
+
+        assert_eq!(cookie.name(), SESSION_COOKIE);
+        assert_eq!(cookie.value(), token.expose());
+        assert_eq!(cookie.http_only(), Some(true));
+        assert_eq!(cookie.secure(), Some(true));
+        assert_eq!(cookie.same_site(), Some(SameSite::Lax));
+        assert_eq!(cookie.path(), Some("/"));
+        assert_eq!(cookie.domain(), None, "host-only");
+        assert_eq!(
+            cookie.max_age(),
+            Some(time::Duration::try_from(SESSION_LIFETIME).unwrap())
+        );
+    }
+
+    #[test]
+    fn the_removal_cookie_matches_the_session_cookie_and_expires_at_once() {
+        let settings = CookieSettings { secure: false };
+
+        let cookie = settings.removal();
+
+        assert_eq!(cookie.name(), SESSION_COOKIE);
+        assert_eq!(cookie.value(), "");
+        assert_eq!(cookie.path(), Some("/"));
+        assert_eq!(cookie.http_only(), Some(true));
+        assert_eq!(cookie.secure(), Some(false));
+        assert_eq!(cookie.max_age(), Some(time::Duration::ZERO));
+    }
+}

--- a/apps/cas/src/sessions/http/extract.rs
+++ b/apps/cas/src/sessions/http/extract.rs
@@ -1,0 +1,48 @@
+//! The `Authenticated` extractor: a handler that takes one runs only for a
+//! request carrying a live session cookie, and gets the session and the
+//! account. Everything else is a 401 before the handler is entered.
+
+use axum::extract::{FromRef, FromRequestParts};
+use axum::http::request::Parts;
+use axum_extra::extract::CookieJar;
+
+use crate::http::ApiState;
+use crate::http::error::ApiError;
+use crate::sessions::http::cookie::SESSION_COOKIE;
+use crate::sessions::{Authenticated, SessionToken};
+
+/// One code for every way a request can fail to be authenticated — no
+/// cookie, a malformed one, an unknown, expired or revoked session — so a
+/// client learns nothing about which sessions exist. The fix is the same in
+/// every case: sign in.
+fn unauthenticated() -> ApiError {
+    ApiError::unauthorized("unauthenticated", "Sign in to continue")
+}
+
+impl<S> FromRequestParts<S> for Authenticated
+where
+    ApiState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state = ApiState::from_ref(state);
+        // Reading the cookie header cannot fail; a missing or unparsable
+        // header is an empty jar.
+        let jar = CookieJar::from_request_parts(parts, &state)
+            .await
+            .unwrap_or_default();
+
+        let token = jar
+            .get(SESSION_COOKIE)
+            .and_then(|cookie| SessionToken::parse(cookie.value()))
+            .ok_or_else(unauthenticated)?;
+
+        state
+            .sessions
+            .authenticate(&token)
+            .await?
+            .ok_or_else(unauthenticated)
+    }
+}

--- a/apps/cas/src/sessions/http/mod.rs
+++ b/apps/cas/src/sessions/http/mod.rs
@@ -1,0 +1,264 @@
+//! The session endpoints (`GET /api/me`, `POST /api/logout`), the cookie that
+//! carries a session and the extractor other contexts use to require one.
+//! Mounted by the transport root in `crate::http`.
+
+pub mod cookie;
+pub mod extract;
+
+use axum::{Json, Router, extract::State, http::StatusCode, routing::get, routing::post};
+use axum_extra::extract::CookieJar;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::accounts::AccountType;
+use crate::http::ApiState;
+use crate::http::error::ApiError;
+use crate::sessions::http::cookie::SESSION_COOKIE;
+use crate::sessions::service::CreateError;
+use crate::sessions::{Authenticated, SessionToken};
+
+pub use cookie::CookieSettings;
+
+/// Registration and login create sessions from their own handlers; the
+/// mapping lives here, with the context that owns the error.
+impl From<CreateError> for ApiError {
+    fn from(error: CreateError) -> Self {
+        match error {
+            // The OS refusing to provide randomness is nothing this code can
+            // name a remedy for.
+            CreateError::Random(error) => ApiError::internal(error),
+            CreateError::Db(error) => ApiError::from(error),
+        }
+    }
+}
+
+pub fn router(state: ApiState) -> Router {
+    Router::new()
+        .route("/me", get(me))
+        .route("/logout", post(logout))
+        .with_state(state)
+}
+
+/// The signed-in account as the dashboard needs it. Nothing about the
+/// session itself but its expiry: the id is server-side state.
+#[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MeResponse {
+    account_id: Uuid,
+    display_name: String,
+    account_type: AccountType,
+    email: Option<String>,
+    #[serde(with = "time::serde::rfc3339")]
+    session_expires_at: OffsetDateTime,
+}
+
+async fn me(authenticated: Authenticated) -> Json<MeResponse> {
+    let Authenticated { session, account } = authenticated;
+
+    Json(MeResponse {
+        account_id: account.id,
+        display_name: account.display_name.into_inner(),
+        account_type: account.r#type,
+        email: account.email,
+        session_expires_at: session.expires_at,
+    })
+}
+
+/// Ends the session the cookie names and clears the cookie. Idempotent and
+/// never a 401: a browser holding an expired or already revoked cookie is
+/// asking to forget it, and the answer to that is yes.
+async fn logout(
+    State(state): State<ApiState>,
+    jar: CookieJar,
+) -> Result<(CookieJar, StatusCode), ApiError> {
+    if let Some(token) = jar
+        .get(SESSION_COOKIE)
+        .and_then(|cookie| SessionToken::parse(cookie.value()))
+    {
+        state.sessions.revoke(&token).await?;
+    }
+
+    // `add`, not `remove`: the jar only emits a removal for a cookie the
+    // request carried, and the answer must clear the cookie either way.
+    Ok((jar.add(state.cookies.removal()), StatusCode::NO_CONTENT))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, header},
+    };
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::accounts::{AccountRepository, NewAccount};
+    use crate::sessions::SessionService;
+    use crate::testing::{display_name, test_state};
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// An account with a live session; returns the cookie header value.
+    async fn signed_in(pool: &PgPool) -> (Uuid, String) {
+        let account = AccountRepository::new(pool.clone())
+            .create(NewAccount::full(display_name("Ada")).with_email("ada@example.com"))
+            .await
+            .unwrap();
+        let issued = SessionService::new(pool.clone())
+            .create(account.id)
+            .await
+            .unwrap();
+        (
+            account.id,
+            format!("{SESSION_COOKIE}={}", issued.token.expose()),
+        )
+    }
+
+    fn get_me(cookie: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder().method("GET").uri("/me");
+        if let Some(cookie) = cookie {
+            request = request.header(header::COOKIE, cookie);
+        }
+        request.body(Body::empty()).unwrap()
+    }
+
+    fn post_logout(cookie: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder().method("POST").uri("/logout");
+        if let Some(cookie) = cookie {
+            request = request.header(header::COOKIE, cookie);
+        }
+        request.body(Body::empty()).unwrap()
+    }
+
+    #[sqlx::test]
+    async fn me_returns_the_signed_in_account(pool: PgPool) {
+        let (account_id, cookie) = signed_in(&pool).await;
+
+        let response = router(test_state(pool))
+            .oneshot(get_me(Some(&cookie)))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["accountId"], account_id.to_string());
+        assert_eq!(body["displayName"], "Ada");
+        assert_eq!(body["accountType"], "full");
+        assert_eq!(body["email"], "ada@example.com");
+        assert!(body["sessionExpiresAt"].is_string());
+        assert!(body.get("sessionId").is_none());
+    }
+
+    #[sqlx::test]
+    async fn me_without_a_cookie_is_401(pool: PgPool) {
+        let response = router(test_state(pool))
+            .oneshot(get_me(None))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            body_json(response).await["error"]["code"],
+            "unauthenticated"
+        );
+    }
+
+    #[sqlx::test]
+    async fn me_with_a_malformed_or_unknown_cookie_is_401(pool: PgPool) {
+        let app = router(test_state(pool));
+        let unknown = format!(
+            "{SESSION_COOKIE}={}",
+            SessionToken::generate().unwrap().expose()
+        );
+
+        for cookie in [
+            format!("{SESSION_COOKIE}=junk"),
+            format!("{SESSION_COOKIE}="),
+            "other=value".to_owned(),
+            unknown,
+        ] {
+            let response = app.clone().oneshot(get_me(Some(&cookie))).await.unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "cookie {cookie:?} must not authenticate"
+            );
+            assert_eq!(
+                body_json(response).await["error"]["code"],
+                "unauthenticated"
+            );
+        }
+    }
+
+    /// Expiry is the server's call: the browser may still hold the cookie,
+    /// the row past its time no longer answers.
+    #[sqlx::test]
+    async fn me_with_an_expired_session_is_401(pool: PgPool) {
+        let (_, cookie) = signed_in(&pool).await;
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("UPDATE sessions SET expires_at = now() - interval '1 second'")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let response = router(test_state(pool))
+            .oneshot(get_me(Some(&cookie)))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[sqlx::test]
+    async fn logout_ends_the_session_and_clears_the_cookie(pool: PgPool) {
+        let (_, cookie) = signed_in(&pool).await;
+        let app = router(test_state(pool));
+
+        let response = app
+            .clone()
+            .oneshot(post_logout(Some(&cookie)))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("logout must clear the cookie")
+            .to_str()
+            .unwrap();
+        assert!(
+            set_cookie.starts_with(&format!("{SESSION_COOKIE}=;")),
+            "{set_cookie}"
+        );
+        assert!(set_cookie.contains("Max-Age=0"), "{set_cookie}");
+        assert!(set_cookie.contains("Path=/"), "{set_cookie}");
+
+        let after = app.oneshot(get_me(Some(&cookie))).await.unwrap();
+        assert_eq!(after.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Logging out of nothing is still a logout: the cookie is cleared and
+    /// nothing is refused.
+    #[sqlx::test]
+    async fn logout_without_a_session_is_a_no_op_that_still_clears_the_cookie(pool: PgPool) {
+        let app = router(test_state(pool));
+        let unknown = format!(
+            "{SESSION_COOKIE}={}",
+            SessionToken::generate().unwrap().expose()
+        );
+
+        for cookie in [None, Some("junk=1"), Some(unknown.as_str())] {
+            let response = app.clone().oneshot(post_logout(cookie)).await.unwrap();
+
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            assert!(response.headers().contains_key(header::SET_COOKIE));
+        }
+    }
+}

--- a/apps/cas/src/sessions/mod.rs
+++ b/apps/cas/src/sessions/mod.rs
@@ -1,0 +1,163 @@
+//! Sessions — what a signed-in browser holds between requests.
+//!
+//! A session is a row in `sessions` and a random token in an HttpOnly cookie.
+//! The row stores the SHA-256 of the token, never the token itself, so a read
+//! of the table does not hand out live sessions. Registration and login create
+//! a session; `GET /api/me` reads it; `POST /api/logout` deletes it. Expiry is
+//! absolute and enforced by the database clock. See
+//! `docs/adr/0004-cookie-sessions.md`.
+//!
+//! This module is the vocabulary: the token, its hash, the row. Issuing,
+//! resolving and revoking sessions is [`service`]; the SQL is `repository`;
+//! the cookie, the extractor and the endpoints are [`http`].
+
+pub mod http;
+mod repository;
+pub mod service;
+
+use std::time::Duration;
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::accounts::Account;
+
+pub use service::SessionService;
+
+/// How long a session lives from the moment it is created. Absolute, not
+/// sliding: the cookie's `Max-Age` and the row's `expires_at` are both derived
+/// from this one number, so the browser and the server give up together.
+pub const SESSION_LIFETIME: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Bytes of entropy in a token. 256 bits: not guessable, and the same size as
+/// the hash that indexes it.
+const TOKEN_BYTES: usize = 32;
+
+/// The secret a browser holds: the base64url form of [`TOKEN_BYTES`] random
+/// bytes. Never logged, never stored; only its [`hash`](Self::hash) reaches
+/// the database. `Debug` is redacted for the same reason.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SessionToken(String);
+
+impl SessionToken {
+    /// Draws a fresh token from the operating system's random source. The
+    /// only failure is the OS refusing to provide randomness, which no
+    /// request can recover from.
+    pub fn generate() -> Result<Self, getrandom::Error> {
+        let mut bytes = [0u8; TOKEN_BYTES];
+        getrandom::fill(&mut bytes)?;
+        Ok(Self(URL_SAFE_NO_PAD.encode(bytes)))
+    }
+
+    /// Accepts a cookie value only if it has the shape of a token this
+    /// service issued, so a request with junk in the cookie is refused before
+    /// it costs a query.
+    pub fn parse(value: &str) -> Option<Self> {
+        let bytes = URL_SAFE_NO_PAD.decode(value).ok()?;
+        (bytes.len() == TOKEN_BYTES).then(|| Self(value.to_owned()))
+    }
+
+    /// What the database stores and looks up.
+    pub fn hash(&self) -> TokenHash {
+        TokenHash(Sha256::digest(self.0.as_bytes()).to_vec())
+    }
+
+    /// The value to put in the cookie. Named so that every use of the secret
+    /// is visible at the call site.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for SessionToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SessionToken(<redacted>)")
+    }
+}
+
+/// SHA-256 of a [`SessionToken`]. Safe to store and to log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TokenHash(Vec<u8>);
+
+impl AsRef<[u8]> for TokenHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A row of `sessions`, without the hash: once found, the row's identity is
+/// its id, and the secret has no business travelling further.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session {
+    pub id: Uuid,
+    pub account_id: Uuid,
+    pub created_at: OffsetDateTime,
+    pub expires_at: OffsetDateTime,
+}
+
+/// Who a request is: the live session it presented and the account it
+/// belongs to. Produced by [`SessionService::authenticate`] and, in the
+/// transport, extracted from the cookie by [`http::extract`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Authenticated {
+    pub session: Session,
+    pub account: Account,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_generated_token_parses_back() {
+        let token = SessionToken::generate().unwrap();
+
+        assert_eq!(SessionToken::parse(token.expose()), Some(token.clone()));
+        assert_eq!(token.expose().len(), 43, "32 bytes of base64url, unpadded");
+    }
+
+    #[test]
+    fn two_tokens_differ() {
+        let first = SessionToken::generate().unwrap();
+        let second = SessionToken::generate().unwrap();
+
+        assert_ne!(first, second);
+        assert_ne!(first.hash(), second.hash());
+    }
+
+    #[test]
+    fn the_hash_is_stable_and_not_the_token() {
+        let token = SessionToken::generate().unwrap();
+
+        assert_eq!(token.hash(), token.hash());
+        assert_eq!(token.hash().as_ref().len(), 32);
+        assert_ne!(token.hash().as_ref(), token.expose().as_bytes());
+    }
+
+    #[test]
+    fn parse_refuses_anything_but_a_token() {
+        for value in [
+            "",
+            "short",
+            &"a".repeat(43),
+            "not base64url!!",
+            &"a".repeat(86),
+        ] {
+            assert!(
+                SessionToken::parse(value).is_none(),
+                "{value:?} must not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn debug_never_prints_the_secret() {
+        let token = SessionToken::generate().unwrap();
+
+        let debug = format!("{token:?}");
+
+        assert!(!debug.contains(token.expose()));
+    }
+}

--- a/apps/cas/src/sessions/repository.rs
+++ b/apps/cas/src/sessions/repository.rs
@@ -1,0 +1,203 @@
+//! Data access for `sessions`. Every query of the context is here; the
+//! functions take an executor so the service can compose a transaction out of
+//! them and out of the accounts context's own functions.
+
+use uuid::Uuid;
+
+use super::{SESSION_LIFETIME, Session, TokenHash};
+
+/// Inserts a session for an account. `expires_at` is measured by the
+/// database clock so every replica agrees on it.
+pub(super) async fn insert<'e, E>(
+    executor: E,
+    account_id: Uuid,
+    token_hash: &TokenHash,
+) -> Result<Session, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let ttl_secs = SESSION_LIFETIME.as_secs_f64();
+
+    sqlx::query_as!(
+        Session,
+        r#"INSERT INTO sessions (account_id, token_hash, expires_at)
+           VALUES ($1, $2, now() + make_interval(secs => $3))
+           RETURNING id, account_id, created_at, expires_at"#,
+        account_id,
+        token_hash.as_ref(),
+        ttl_secs,
+    )
+    .fetch_one(executor)
+    .await
+}
+
+/// The session a token names, if it exists and has not expired. An expired
+/// row is the same as no row: it is not returned, and it is not removed here
+/// either, so that housekeeping stays out of the request path.
+pub(super) async fn find_live<'e, E>(
+    executor: E,
+    token_hash: &TokenHash,
+) -> Result<Option<Session>, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as!(
+        Session,
+        r#"SELECT id, account_id, created_at, expires_at
+           FROM sessions
+           WHERE token_hash = $1 AND expires_at > now()"#,
+        token_hash.as_ref(),
+    )
+    .fetch_optional(executor)
+    .await
+}
+
+/// Deletes the session a token names. `Ok(false)` when there was none, which
+/// a logout treats the same as success.
+pub(super) async fn delete<'e, E>(executor: E, token_hash: &TokenHash) -> Result<bool, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let result = sqlx::query!(
+        "DELETE FROM sessions WHERE token_hash = $1",
+        token_hash.as_ref(),
+    )
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accounts::{AccountRepository, NewAccount};
+    use crate::sessions::SessionToken;
+    use crate::testing::display_name;
+    use sqlx::PgPool;
+
+    async fn account(pool: &PgPool) -> Uuid {
+        AccountRepository::new(pool.clone())
+            .create(NewAccount::full(display_name("Ada")))
+            .await
+            .unwrap()
+            .id
+    }
+
+    /// Moves a session's expiry into the past. Unchecked query: see
+    /// docs/TESTS.md.
+    async fn expire(pool: &PgPool, id: Uuid) {
+        sqlx::query("UPDATE sessions SET expires_at = now() - interval '1 second' WHERE id = $1")
+            .bind(id)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn count(pool: &PgPool) -> i64 {
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query_scalar("SELECT count(*) FROM sessions")
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn insert_and_find_round_trip(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+
+        let inserted = insert(&pool, account_id, &hash).await.unwrap();
+        let found = find_live(&pool, &hash).await.unwrap();
+
+        assert_eq!(found, Some(inserted.clone()));
+        assert_eq!(inserted.account_id, account_id);
+        assert!(inserted.expires_at > inserted.created_at);
+    }
+
+    #[sqlx::test]
+    async fn find_is_none_for_an_unknown_hash(pool: PgPool) {
+        let found = find_live(&pool, &SessionToken::generate().unwrap().hash())
+            .await
+            .unwrap();
+
+        assert_eq!(found, None);
+    }
+
+    #[sqlx::test]
+    async fn an_expired_session_is_not_found_and_not_removed(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        let session = insert(&pool, account_id, &hash).await.unwrap();
+        expire(&pool, session.id).await;
+
+        let found = find_live(&pool, &hash).await.unwrap();
+
+        assert_eq!(found, None);
+        assert_eq!(count(&pool).await, 1, "cleanup is not this query's job");
+    }
+
+    /// The row must give up when the cookie does: both are derived from
+    /// `SESSION_LIFETIME`.
+    #[sqlx::test]
+    async fn a_session_lives_for_the_lifetime(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let session = insert(&pool, account_id, &SessionToken::generate().unwrap().hash())
+            .await
+            .unwrap();
+
+        // In seconds: a timestamp difference of 30 days comes back as an
+        // interval of days, not microseconds. Unchecked query: see
+        // docs/TESTS.md.
+        let lifetime_secs: f64 = sqlx::query_scalar(
+            "SELECT extract(epoch FROM expires_at - created_at)::float8 FROM sessions WHERE id = $1",
+        )
+        .bind(session.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(lifetime_secs, SESSION_LIFETIME.as_secs_f64());
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_the_session_once(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        insert(&pool, account_id, &hash).await.unwrap();
+
+        assert!(delete(&pool, &hash).await.unwrap());
+        assert!(!delete(&pool, &hash).await.unwrap());
+        assert_eq!(find_live(&pool, &hash).await.unwrap(), None);
+    }
+
+    /// The same token can never name two sessions; the constraint is what
+    /// makes the hash lookup unambiguous.
+    #[sqlx::test]
+    async fn a_hash_is_unique(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        insert(&pool, account_id, &hash).await.unwrap();
+
+        let error = insert(&pool, account_id, &hash).await.unwrap_err();
+
+        assert!(matches!(error, sqlx::Error::Database(db) if db.is_unique_violation()));
+    }
+
+    #[sqlx::test]
+    async fn deleting_an_account_deletes_its_sessions(pool: PgPool) {
+        let account_id = account(&pool).await;
+        insert(&pool, account_id, &SessionToken::generate().unwrap().hash())
+            .await
+            .unwrap();
+
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("DELETE FROM accounts WHERE id = $1")
+            .bind(account_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(count(&pool).await, 0);
+    }
+}

--- a/apps/cas/src/sessions/service.rs
+++ b/apps/cas/src/sessions/service.rs
@@ -1,0 +1,196 @@
+//! Issuing, resolving and revoking sessions.
+//!
+//! `create` is what registration and login call once an account is proven;
+//! `authenticate` is what the cookie extractor calls on every authenticated
+//! request; `revoke` is logout. The secret token exists in memory only
+//! between `create` and the response that sets the cookie.
+
+use sqlx::PgPool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::{Authenticated, Session, SessionToken, repository};
+use crate::accounts;
+
+#[derive(Debug, Error)]
+pub enum CreateError {
+    /// The operating system refused to provide randomness. Nothing a request
+    /// can do about it.
+    #[error("failed to generate a session token: {0}")]
+    Random(#[source] getrandom::Error),
+
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+/// A session just created, with the token the browser must be given. The
+/// token is returned exactly once: the row keeps only its hash.
+#[derive(Debug)]
+pub struct IssuedSession {
+    pub token: SessionToken,
+    pub session: Session,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionService {
+    pool: PgPool,
+}
+
+impl SessionService {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Issues a session for an account that has just proven who it is.
+    ///
+    /// Signing in is activity: the account's `last_seen_at` moves in the same
+    /// transaction, so a session and the trace it leaves on the account are
+    /// written together or not at all.
+    pub async fn create(&self, account_id: Uuid) -> Result<IssuedSession, CreateError> {
+        let token = SessionToken::generate().map_err(CreateError::Random)?;
+
+        let mut tx = self.pool.begin().await?;
+        let session = repository::insert(&mut *tx, account_id, &token.hash()).await?;
+        accounts::touch_last_seen(&mut *tx, account_id).await?;
+        tx.commit().await?;
+
+        Ok(IssuedSession { token, session })
+    }
+
+    /// Resolves a token to the session and account it names. `Ok(None)` for a
+    /// token that is unknown, expired or revoked, or whose account is gone.
+    pub async fn authenticate(
+        &self,
+        token: &SessionToken,
+    ) -> Result<Option<Authenticated>, sqlx::Error> {
+        let Some(session) = repository::find_live(&self.pool, &token.hash()).await? else {
+            return Ok(None);
+        };
+        // The cascade removes sessions with their account, so a missing
+        // account here is a race with that delete, and the answer is the same
+        // as if the session had already gone.
+        let Some(account) = accounts::get(&self.pool, session.account_id).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(Authenticated { session, account }))
+    }
+
+    /// Ends the session a token names. `Ok(false)` when there was none:
+    /// logging out of nothing is not an error.
+    pub async fn revoke(&self, token: &SessionToken) -> Result<bool, sqlx::Error> {
+        repository::delete(&self.pool, &token.hash()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::accounts::{Account, AccountRepository, NewAccount};
+    use crate::testing::display_name;
+
+    async fn account(pool: &PgPool) -> Account {
+        AccountRepository::new(pool.clone())
+            .create(NewAccount::full(display_name("Ada")))
+            .await
+            .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn a_created_session_authenticates_its_account(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool);
+
+        let issued = service.create(account.id).await.unwrap();
+        let authenticated = service
+            .authenticate(&issued.token)
+            .await
+            .unwrap()
+            .expect("the session was just created");
+
+        assert_eq!(authenticated.session, issued.session);
+        assert_eq!(authenticated.account.id, account.id);
+        assert_eq!(authenticated.account.display_name, account.display_name);
+    }
+
+    #[sqlx::test]
+    async fn creating_a_session_marks_the_account_as_seen(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        // Push the timestamp into the past so the update is observable within
+        // one test. Unchecked query: see docs/TESTS.md.
+        sqlx::query("UPDATE accounts SET last_seen_at = now() - interval '1 day' WHERE id = $1")
+            .bind(account.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let issued = service.create(account.id).await.unwrap();
+
+        let seen = AccountRepository::new(pool)
+            .get(account.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(seen.last_seen_at >= issued.session.created_at);
+    }
+
+    #[sqlx::test]
+    async fn an_unknown_token_does_not_authenticate(pool: PgPool) {
+        let service = SessionService::new(pool);
+
+        let authenticated = service
+            .authenticate(&SessionToken::generate().unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(authenticated, None);
+    }
+
+    #[sqlx::test]
+    async fn a_revoked_session_does_not_authenticate(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool);
+        let issued = service.create(account.id).await.unwrap();
+
+        assert!(service.revoke(&issued.token).await.unwrap());
+
+        assert_eq!(service.authenticate(&issued.token).await.unwrap(), None);
+        assert!(
+            !service.revoke(&issued.token).await.unwrap(),
+            "revoking twice finds nothing"
+        );
+    }
+
+    #[sqlx::test]
+    async fn an_expired_session_does_not_authenticate(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        let issued = service.create(account.id).await.unwrap();
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("UPDATE sessions SET expires_at = now() - interval '1 second' WHERE id = $1")
+            .bind(issued.session.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(service.authenticate(&issued.token).await.unwrap(), None);
+    }
+
+    /// A session for an account that does not exist cannot be written: the
+    /// foreign key holds, and the failed transaction leaves nothing behind.
+    #[sqlx::test]
+    async fn a_session_needs_an_account(pool: PgPool) {
+        let service = SessionService::new(pool.clone());
+
+        let error = service.create(Uuid::new_v4()).await.unwrap_err();
+
+        assert!(matches!(error, CreateError::Db(_)));
+        // Unchecked query: see docs/TESTS.md.
+        let count: i64 = sqlx::query_scalar("SELECT count(*) FROM sessions")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+}

--- a/apps/cas/src/testing.rs
+++ b/apps/cas/src/testing.rs
@@ -18,10 +18,35 @@ use webauthn_rs_proto::{
 };
 
 use crate::accounts::DisplayName;
+use crate::http::ApiState;
+use crate::sessions::http::CookieSettings;
+use crate::sessions::{SessionService, SessionToken};
 use crate::webauthn::build_webauthn;
+use crate::webauthn::login::LoginService;
 use crate::webauthn::registration::{
     Registered, RegistrationService, start_discoverable_registration,
 };
+
+/// The API state the handler tests run against: every service on the given
+/// pool, cookies as the development origin would have them.
+pub fn test_state(pool: PgPool) -> ApiState {
+    ApiState {
+        registration: RegistrationService::new(test_webauthn(), pool.clone()),
+        login: LoginService::new(test_webauthn(), pool.clone()),
+        sessions: SessionService::new(pool),
+        cookies: CookieSettings::for_origin(&test_origin()),
+    }
+}
+
+/// The session cookie a `Set-Cookie` header carries, parsed back into the
+/// token, so a test can check what the browser was given and use it.
+pub fn session_cookie(response: &axum::response::Response) -> Option<SessionToken> {
+    let header = response.headers().get(axum::http::header::SET_COOKIE)?;
+    let cookie = axum_extra::extract::cookie::Cookie::parse(header.to_str().ok()?).ok()?;
+    (cookie.name() == crate::sessions::http::cookie::SESSION_COOKIE)
+        .then(|| SessionToken::parse(cookie.value()))
+        .flatten()
+}
 
 struct ResidentCredential {
     rp_id: String,

--- a/apps/cas/src/webauthn/http/login.rs
+++ b/apps/cas/src/webauthn/http/login.rs
@@ -2,6 +2,7 @@
 //! may answer, and verifying the browser's assertion.
 
 use axum::{Json, extract::State};
+use axum_extra::extract::CookieJar;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use webauthn_rs::prelude::{CredentialID, PublicKeyCredential, RequestChallengeResponse};
@@ -75,16 +76,23 @@ pub(super) async fn get_login_options(
     }))
 }
 
+/// A finished login signs the account in: the response sets the session
+/// cookie alongside the body.
 pub(super) async fn verify_login(
     State(state): State<ApiState>,
+    jar: CookieJar,
     AppJson(data): AppJson<VerifyLoginData>,
-) -> Result<Json<VerifyLoginResponse>, ApiError> {
+) -> Result<(CookieJar, Json<VerifyLoginResponse>), ApiError> {
     let logged_in = state.login.finish(data.login_id, &data.response).await?;
+    let issued = state.sessions.create(logged_in.account.id).await?;
 
-    Ok(Json(VerifyLoginResponse {
-        account_id: logged_in.account.id,
-        credential_id: logged_in.credential.passkey.cred_id().clone(),
-    }))
+    Ok((
+        jar.add(state.cookies.session(&issued.token)),
+        Json(VerifyLoginResponse {
+            account_id: logged_in.account.id,
+            credential_id: logged_in.credential.passkey.cred_id().clone(),
+        }),
+    ))
 }
 
 #[cfg(test)]
@@ -99,22 +107,19 @@ mod tests {
     use sqlx::{PgPool, postgres::PgPoolOptions};
     use tower::ServiceExt;
 
+    use crate::sessions::SessionService;
     use crate::testing::{
-        ResidentSoftPasskey, register_soft_passkey, soft_passkey_assertion, test_origin,
-        test_webauthn,
+        ResidentSoftPasskey, register_soft_passkey, session_cookie, soft_passkey_assertion,
+        test_origin, test_state, test_webauthn,
     };
     use crate::webauthn::CEREMONY_TIMEOUT;
     use crate::webauthn::http::router;
-    use crate::webauthn::login::LoginService;
-    use crate::webauthn::registration::{RegistrationService, start_discoverable_registration};
+    use crate::webauthn::registration::start_discoverable_registration;
     use crate::webauthn::repository::PasskeyRepository;
     use webauthn_authenticator_rs::WebauthnAuthenticator;
 
     fn test_app(pool: PgPool) -> Router {
-        router(ApiState {
-            registration: RegistrationService::new(test_webauthn(), pool.clone()),
-            login: LoginService::new(test_webauthn(), pool),
-        })
+        router(test_state(pool))
     }
 
     /// For requests that fail before any query: a lazy pool never connects,
@@ -200,6 +205,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let token = session_cookie(&response).expect("login signs the account in");
         let body = body_json(response).await;
         let account_id: Uuid = serde_json::from_value(body["accountId"].clone()).unwrap();
         assert_eq!(account_id, registered.account.id);
@@ -209,11 +215,19 @@ mod tests {
         // The stored credential stays server-side.
         assert!(body.get("credential").is_none());
 
-        let credentials = PasskeyRepository::new(pool)
+        let credentials = PasskeyRepository::new(pool.clone())
             .list_for_account(account_id)
             .await
             .unwrap();
         assert!(credentials[0].last_used_at.is_some());
+
+        // The cookie names a live session of the signed-in account.
+        let authenticated = SessionService::new(pool)
+            .authenticate(&token)
+            .await
+            .unwrap()
+            .expect("the cookie must carry a live session");
+        assert_eq!(authenticated.account.id, account_id);
     }
 
     /// The wire shape of a discoverable challenge: nothing names the user or

--- a/apps/cas/src/webauthn/http/registration.rs
+++ b/apps/cas/src/webauthn/http/registration.rs
@@ -2,6 +2,7 @@
 //! browser's answer.
 
 use axum::{Json, extract::State};
+use axum_extra::extract::CookieJar;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use webauthn_rs::prelude::{CreationChallengeResponse, CredentialID, RegisterPublicKeyCredential};
@@ -101,19 +102,26 @@ pub(super) async fn get_registration_options(
     }))
 }
 
+/// A finished registration signs the new account in: the response sets the
+/// session cookie alongside the body.
 pub(super) async fn verify_registration(
     State(state): State<ApiState>,
+    jar: CookieJar,
     AppJson(data): AppJson<VerifyRegistrationData>,
-) -> Result<Json<VerifyRegistrationResponse>, ApiError> {
+) -> Result<(CookieJar, Json<VerifyRegistrationResponse>), ApiError> {
     let registered = state
         .registration
         .finish(data.registration_id, &data.response)
         .await?;
+    let issued = state.sessions.create(registered.account.id).await?;
 
-    Ok(Json(VerifyRegistrationResponse {
-        account_id: registered.account.id,
-        credential_id: registered.credential.passkey.cred_id().clone(),
-    }))
+    Ok((
+        jar.add(state.cookies.session(&issued.token)),
+        Json(VerifyRegistrationResponse {
+            account_id: registered.account.id,
+            credential_id: registered.credential.passkey.cred_id().clone(),
+        }),
+    ))
 }
 
 #[cfg(test)]
@@ -129,19 +137,15 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::accounts::{AccountRepository, AccountType};
-    use crate::testing::{soft_passkey_registration, test_webauthn};
+    use crate::sessions::SessionService;
+    use crate::testing::{session_cookie, soft_passkey_registration, test_state};
     use crate::webauthn::CEREMONY_TIMEOUT;
     use crate::webauthn::http::router;
-    use crate::webauthn::login::LoginService;
     use crate::webauthn::passkeys::DEFAULT_PASSKEY_NAME;
-    use crate::webauthn::registration::RegistrationService;
     use crate::webauthn::repository::PasskeyRepository;
 
     fn test_app(pool: PgPool) -> Router {
-        router(ApiState {
-            registration: RegistrationService::new(test_webauthn(), pool.clone()),
-            login: LoginService::new(test_webauthn(), pool),
-        })
+        router(test_state(pool))
     }
 
     /// For requests that fail before any query: a lazy pool never connects,
@@ -228,6 +232,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let token = session_cookie(&response).expect("registration signs the account in");
         let body = body_json(response).await;
         let account_id: Uuid = serde_json::from_value(body["accountId"].clone()).unwrap();
         assert_ne!(account_id, options.registration_id);
@@ -244,12 +249,20 @@ mod tests {
         assert_eq!(account.display_name.as_ref(), "Ada");
         assert_eq!(account.r#type, AccountType::Full);
 
-        let credentials = PasskeyRepository::new(pool)
+        let credentials = PasskeyRepository::new(pool.clone())
             .list_for_account(account_id)
             .await
             .unwrap();
         assert_eq!(credentials.len(), 1);
         assert_eq!(credentials[0].name, DEFAULT_PASSKEY_NAME);
+
+        // The cookie names a live session of the new account.
+        let authenticated = SessionService::new(pool)
+            .authenticate(&token)
+            .await
+            .unwrap()
+            .expect("the cookie must carry a live session");
+        assert_eq!(authenticated.account.id, account_id);
     }
 
     /// The challenge answers exactly one request; a replayed finish finds no

--- a/apps/cas/tests/client/src/main.ts
+++ b/apps/cas/tests/client/src/main.ts
@@ -18,6 +18,12 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
     <br />
 
+    <button id="me">Who am I?</button>
+
+    <button id="logout">Sign out</button>
+
+    <br />
+
     <div id="success"></div>
     <div id="error"></div>
   </div>
@@ -25,13 +31,46 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
 const elemRegister = document.getElementById('register')
 const elemLogin = document.getElementById('login')
+const elemMe = document.getElementById('me')
+const elemLogout = document.getElementById('logout')
 const elemDisplayName = document.getElementById('displayName') as HTMLInputElement | null
 const elemSuccess = document.getElementById('success')
 const elemError = document.getElementById('error')
 
-if (!elemRegister || !elemLogin || !elemDisplayName || !elemSuccess || !elemError) {
+if (!elemRegister || !elemLogin || !elemMe || !elemLogout || !elemDisplayName || !elemSuccess || !elemError) {
   throw new Error('Register form not found')
 }
+
+// The session lives in an HttpOnly cookie set by the API's origin; a
+// cross-origin fetch only sends and accepts it with credentials included.
+elemMe.addEventListener('click', async () => {
+  elemSuccess.innerHTML = ''
+  elemError.innerHTML = ''
+
+  const response = await fetch(`${API_URL}/api/me`, { credentials: 'include' })
+  const json = await response.json()
+
+  if (response.ok) {
+    elemSuccess.innerHTML = `Signed in as ${json.displayName} (${json.accountType}), account ${json.accountId}, session until ${json.sessionExpiresAt}`
+  } else if (json?.error?.code === 'unauthenticated') {
+    elemError.innerText = 'Not signed in.'
+  } else {
+    elemError.innerHTML = `Oh no, something went wrong! Response: <pre>${JSON.stringify(json)}</pre>`
+  }
+})
+
+elemLogout.addEventListener('click', async () => {
+  elemSuccess.innerHTML = ''
+  elemError.innerHTML = ''
+
+  const response = await fetch(`${API_URL}/api/logout`, { method: 'POST', credentials: 'include' })
+
+  if (response.ok) {
+    elemSuccess.innerText = 'Signed out.'
+  } else {
+    elemError.innerHTML = `Oh no, something went wrong! Response: <pre>${await response.text()}</pre>`
+  }
+})
 
 // Sign-in asks for nothing: the browser lists the passkeys it holds for this
 // relying party and the chosen one names the account.
@@ -60,8 +99,11 @@ elemLogin.addEventListener('click', async () => {
     throw error
   }
 
+  // A finished login sets the session cookie; the browser only keeps it
+  // from a cross-origin response when credentials are included.
   const verificationResp = await fetch(`${API_URL}/api/webauthn/verify-login`, {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },
@@ -123,8 +165,11 @@ elemRegister.addEventListener('click', async () => {
 
   // POST the response to the endpoint that calls
   // @simplewebauthn/server -> verifyRegistrationResponse()
+  // A finished registration sets the session cookie; the browser only keeps
+  // it from a cross-origin response when credentials are included.
   const verificationResp = await fetch(`${API_URL}/api/webauthn/verify-registration`, {
     method: 'POST',
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
Closes #667.

## What

- `sessions` table: `token_hash` (SHA-256 of the cookie token, unique), `account_id`, absolute `expires_at` measured by the database clock. Expired rows are ignored, not removed: cleanup stays a scheduled job (PLAN open question updated).
- Cookie `cas_session`: 256 random bits base64url, `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age` = 30 days, `Secure` when `CAS_ORIGIN` is https.
- `POST /api/webauthn/verify-registration` and `POST /api/webauthn/verify-login` now create a session and set the cookie alongside their body. Session creation also moves `accounts.last_seen_at`.
- `GET /api/me` → account id, display name, type, email, session expiry. `POST /api/logout` → 204, deletes the session and clears the cookie; idempotent, never a 401.
- `Authenticated` axum extractor (`sessions::http::extract`): one `401 unauthenticated` for no cookie, a malformed one, an unknown, expired or revoked session. Ready for passkey management (#668).
- CORS: `allow_credentials(true)`, so methods and headers are enumerated instead of `Any`.
- Test client: `credentials: 'include'`, "Who am I?" and "Sign out" buttons.
- Docs: `docs/adr/0004-cookie-sessions.md`; MIGRATIONS.md gets the `sqlx migrate run` note for a branch that adds a table together with its first queries.

## Not in scope

- Sliding expiry, session listing and "sign out everywhere": later, with a product need.
- Deleting a passkey does not end the sessions opened with it (noted in the ADR for #668).

## Tests

`cargo test` with `SQLX_OFFLINE=true`: 132 passed. New coverage: token shape and redaction, cookie attributes, repository round trip / expiry / uniqueness / cascade, service create / authenticate / revoke / expired, `/me` and `/logout` through the router, cookie set and live on register and login, both contexts reachable under `/api`, CORS credentials header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
