### PR TITLE
feat(cas): Fetch Metadata / Origin check on mutating requests (#696)

### DIFF
--- a/apps/cas/docs/LAYOUT.md
+++ b/apps/cas/docs/LAYOUT.md
@@ -20,6 +20,7 @@ apps/cas/
     http/              transport root: mounts the contexts, owns the wire contract
       mod.rs           router, middleware stack, pool construction
       error.rs         ApiError, the error contract on the wire
+      fetch_metadata.rs  the CSRF line on /api (ADR 0005)
     <context>/         one directory per bounded context (accounts, webauthn, ...)
       mod.rs           domain types, invariants, re-exports
       <concept>.rs     more domain: newtypes, states, rules

--- a/apps/cas/docs/adr/0004-cookie-sessions.md
+++ b/apps/cas/docs/adr/0004-cookie-sessions.md
@@ -60,8 +60,8 @@ change. It has one known gap: `POST /api/logout` takes no body, so a cross-site
 HTML form can reach it and only `SameSite=Lax` stands in the way. OWASP counts
 `SameSite` as defence in depth, not as a defence on its own. The exposure is a
 forced sign-out, nothing more, and it is closed by a Fetch Metadata / `Origin`
-check on every mutating request in
-[#696](https://github.com/MemeBattle/monorepo/issues/696), which also covers
+check on every mutating request (ADR 0005, from
+[#696](https://github.com/MemeBattle/monorepo/issues/696)), which also covers
 body-less endpoints to come (passkey delete, #668).
 
 **(f) Registration and login sign the account in.** Their finish handlers
@@ -101,8 +101,8 @@ context's transport and is the one thing other contexts import from it.
 - The session id is the row's identity for the future management screen; the
   token never identifies a session anywhere but in the lookup.
 - Hardening that OWASP recommends and this change leaves out is tracked
-  separately: the CSRF layer ([#696](https://github.com/MemeBattle/monorepo/issues/696)),
-  the timeout decision ([#697](https://github.com/MemeBattle/monorepo/issues/697)),
+  separately: the CSRF layer ([#696](https://github.com/MemeBattle/monorepo/issues/696),
+  done in ADR 0005), the timeout decision ([#697](https://github.com/MemeBattle/monorepo/issues/697)),
   `Cache-Control: no-store` and `Clear-Site-Data`
   ([#698](https://github.com/MemeBattle/monorepo/issues/698)), session
   lifecycle logging ([#699](https://github.com/MemeBattle/monorepo/issues/699))

--- a/apps/cas/docs/adr/0005-fetch-metadata-csrf.md
+++ b/apps/cas/docs/adr/0005-fetch-metadata-csrf.md
@@ -1,0 +1,85 @@
+# 5. Fetch Metadata as the CSRF line
+
+## Status
+
+Accepted (2026-09-12), with [#696](https://github.com/MemeBattle/monorepo/issues/696).
+
+## Context
+
+The session cookie (ADR 0004) is `SameSite=Lax`, and a JSON body forces a
+CORS preflight on every state-changing request that has one. Together they
+kept cross-site requests out, with one gap: `POST /api/logout` takes no body,
+so a form on another site can post to it with the victim's cookie attached
+and only `SameSite=Lax` stands in the way. Passkey management (#668) adds
+`DELETE` endpoints with the same shape, and more will follow.
+
+OWASP counts `SameSite` as defence in depth, not a defence on its own: the
+browser's default for a cookie without the attribute has moved more than once,
+and an attacker on a sibling subdomain is same-site by definition. The
+[OWASP CSRF cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
+asks for a primary defence: a synchronizer token, a double-submit cookie, or
+a check of where the request came from.
+
+CAS has no HTML forms of its own yet and its frontend talks JSON across
+origins. A token scheme would add state, a header the frontend has to fetch
+and echo, and a failure mode for every client. The browser already states
+where a request came from, in `Sec-Fetch-Site` (Fetch Metadata, every
+current browser since 2023) and in `Origin`.
+
+## Decision
+
+**(a) A layer on the `/api` router refuses a mutating request that does not
+come from this site or from an allowed origin.** Mutating means any method
+but `GET`, `HEAD` and `OPTIONS`. The layer wraps the whole `/api` router,
+fallback included, so a new endpoint is protected by where it is mounted and
+not by remembering to add anything. `/health` stays outside: read-only, and
+probed by machines that send no browser headers.
+
+**(b) `Sec-Fetch-Site` is the authority when present.** `same-origin`,
+`same-site` and `none` pass. `same-site` is admitted because the production
+frontend lives on a sibling subdomain of the API; the `__Host-` cookie prefix
+(#700) handles what a sibling could do to the cookie itself. `none` is a
+user-initiated request (typed URL, bookmark), which a third party cannot
+forge. `cross-site` passes only with an `Origin` in `CAS_CORS_ORIGINS`. A
+value this code does not know is read as `cross-site`: the safe reading of
+an unknown claim.
+
+**(c) Without Fetch Metadata, `Origin` decides alone.** A request with no
+`Sec-Fetch-Site` is a browser from before Fetch Metadata or not a browser at
+all (curl, a server, a test). It passes when `Origin` is absent or allowed.
+Non-browser clients carry no cookie that was set by someone else, so they
+have nothing to forge; a browser that sends `Origin` but no Fetch Metadata is
+held to the origin list. An `Origin` of `null` is not an allowed one.
+
+**(d) The origin list is the CORS list.** One configuration variable says
+which sites may talk to the API with credentials, and both the preflight and
+this check read it. Comparison is exact, byte for byte, on the serialized
+origin: no trailing slash, no case folding, no suffix matching.
+
+**(e) Refusal is `403` with code `cross_site_request`**, in the standard
+`ApiError` shape, before the handler runs and before any database access.
+The reason (no Fetch Metadata vs. a cross-site claim) is logged at `warn`
+with the method, path and both headers; the client sees one answer.
+
+## Consequences
+
+- The cross-site form post to `/api/logout` from ADR 0004 (e) now fails at
+  the layer and leaves the session untouched. Every body-less mutating
+  endpoint to come, including passkey delete, is covered on arrival.
+- `GET` is untouched by the layer. The OIDC `/authorize` redirect (M2)
+  arrives as a cross-site top-level navigation and must keep working; a
+  `GET` that mutates state would bypass the check, so there must never be
+  one.
+- A mutating request from the frontend must carry either Fetch Metadata or
+  an `Origin`. Browsers send both with `fetch`; a test that builds requests
+  by hand and sends neither passes on the non-browser branch.
+- Adding a frontend origin means adding it to `CAS_CORS_ORIGINS`, which is
+  already true for CORS. A misconfigured list now fails mutating requests
+  with `403` instead of silently working over `SameSite=Lax` alone.
+- No token, no per-request state, no header the frontend has to fetch and
+  echo. If an HTML form ever appears in CAS itself (a consent screen in M2
+  may be one), it is same-origin and passes the same check; no second
+  mechanism is needed.
+- The `Sec-Fetch-Site` header cannot be set by script, and `Origin` cannot
+  be spoofed by a browser. A non-browser client can send anything, but it
+  has no victim's cookie to attach.

--- a/apps/cas/docs/adr/0005-fetch-metadata-csrf.md
+++ b/apps/cas/docs/adr/0005-fetch-metadata-csrf.md
@@ -35,14 +35,15 @@ fallback included, so a new endpoint is protected by where it is mounted and
 not by remembering to add anything. `/health` stays outside: read-only, and
 probed by machines that send no browser headers.
 
-**(b) `Sec-Fetch-Site` is the authority when present.** `same-origin`,
-`same-site` and `none` pass. `same-site` is admitted because the production
-frontend lives on a sibling subdomain of the API; the `__Host-` cookie prefix
-(#700) handles what a sibling could do to the cookie itself. `none` is a
-user-initiated request (typed URL, bookmark), which a third party cannot
-forge. `cross-site` passes only with an `Origin` in `CAS_CORS_ORIGINS`. A
-value this code does not know is read as `cross-site`: the safe reading of
-an unknown claim.
+**(b) `Sec-Fetch-Site` is the authority when present.** `same-origin` and
+`none` pass. `none` is a user-initiated request (typed URL, bookmark), which
+a third party cannot forge. `same-site` and `cross-site` pass only with an
+`Origin` in `CAS_CORS_ORIGINS`. A sibling subdomain is same-site, shares the
+cookie jar (`SameSite=Lax` does not withhold the cookie from it) and can post
+an HTML form that no CORS preflight ever sees; it is not this service and is
+trusted only when the origin list names it. The frontend is in that list
+already, wherever it is served from. A value this code does not know is read
+as `cross-site`: the safe reading of an unknown claim.
 
 **(c) Without Fetch Metadata, `Origin` decides alone.** A request with no
 `Sec-Fetch-Site` is a browser from before Fetch Metadata or not a browser at

--- a/apps/cas/src/http/error.rs
+++ b/apps/cas/src/http/error.rs
@@ -37,6 +37,10 @@ impl ApiError {
         Self::client(StatusCode::UNAUTHORIZED, code, message)
     }
 
+    pub fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self::client(StatusCode::FORBIDDEN, code, message)
+    }
+
     pub fn not_found(code: &'static str, message: impl Into<String>) -> Self {
         Self::client(StatusCode::NOT_FOUND, code, message)
     }

--- a/apps/cas/src/http/fetch_metadata.rs
+++ b/apps/cas/src/http/fetch_metadata.rs
@@ -1,0 +1,346 @@
+//! The CSRF line for `/api`: a mutating request must come from this site or
+//! from an origin the frontend is served from. Decided in ADR 0005.
+//!
+//! The check reads the browser's Fetch Metadata (`Sec-Fetch-Site`) and falls
+//! back to `Origin` for clients that send neither. It costs no state and no
+//! token: the browser states where a request came from and the server says
+//! whether that is good enough.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    extract::{Request, State},
+    http::{HeaderMap, HeaderValue, Method, header},
+    middleware::{self, Next},
+    response::Response,
+};
+
+use crate::http::error::ApiError;
+
+const SEC_FETCH_SITE: &str = "sec-fetch-site";
+
+/// The origins a cross-site mutating request may come from: the frontend in
+/// development and any other site CORS already admits. Shared by every
+/// request, hence the `Arc`.
+#[derive(Debug, Clone)]
+pub struct AllowedOrigins(Arc<[HeaderValue]>);
+
+impl AllowedOrigins {
+    pub fn new(origins: Vec<HeaderValue>) -> Self {
+        Self(origins.into())
+    }
+
+    fn contains(&self, origin: &HeaderValue) -> bool {
+        self.0.iter().any(|allowed| allowed == origin)
+    }
+}
+
+/// Wraps every route of `router`, including its fallback, in the check. The
+/// `/api` router goes through here before it is mounted.
+pub fn guard(router: Router, origins: AllowedOrigins) -> Router {
+    router.layer(middleware::from_fn_with_state(origins, reject_cross_site))
+}
+
+async fn reject_cross_site(
+    State(origins): State<AllowedOrigins>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    verdict(request.method(), request.headers(), &origins).map_err(|rejection| {
+        tracing::warn!(
+            method = %request.method(),
+            path = request.uri().path(),
+            sec_fetch_site = ?request.headers().get(SEC_FETCH_SITE),
+            origin = ?request.headers().get(header::ORIGIN),
+            reason = rejection.reason(),
+            "cross-site mutating request rejected"
+        );
+        ApiError::forbidden("cross_site_request", "Cross-site requests are not allowed")
+    })?;
+
+    Ok(next.run(request).await)
+}
+
+/// Why a request was turned away. Logged, never sent to the client: the
+/// response is the same 403 whatever the reason.
+#[derive(Debug, PartialEq, Eq)]
+enum Rejection {
+    /// `Sec-Fetch-Site` names another site and `Origin` is not an allowed one.
+    CrossSite,
+    /// No Fetch Metadata, and an `Origin` that is not an allowed one.
+    UnknownOrigin,
+}
+
+impl Rejection {
+    fn reason(&self) -> &'static str {
+        match self {
+            Rejection::CrossSite => "cross_site",
+            Rejection::UnknownOrigin => "unknown_origin",
+        }
+    }
+}
+
+/// The decision, as a pure function of the method and the headers.
+///
+/// Safe methods always pass: `GET` navigations from other sites are how the
+/// future OIDC `/authorize` arrives, and a safe method changes nothing. For
+/// the rest, `Sec-Fetch-Site` is the authority when present: `same-origin`,
+/// `same-site` and `none` (a user-initiated request) pass; `cross-site`, and
+/// any value this code does not know, passes only with an allowed `Origin`.
+/// Without Fetch Metadata the request is an old browser or a non-browser
+/// client, and `Origin` decides alone: absent or allowed passes.
+fn verdict(
+    method: &Method,
+    headers: &HeaderMap,
+    origins: &AllowedOrigins,
+) -> Result<(), Rejection> {
+    if matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS) {
+        return Ok(());
+    }
+
+    let origin_allowed = || {
+        headers
+            .get(header::ORIGIN)
+            .is_some_and(|origin| origins.contains(origin))
+    };
+
+    match headers.get(SEC_FETCH_SITE).map(HeaderValue::as_bytes) {
+        Some(b"same-origin" | b"same-site" | b"none") => Ok(()),
+        Some(_) if origin_allowed() => Ok(()),
+        Some(_) => Err(Rejection::CrossSite),
+        None if headers.get(header::ORIGIN).is_none() || origin_allowed() => Ok(()),
+        None => Err(Rejection::UnknownOrigin),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, StatusCode},
+        routing::{get, post},
+    };
+    use tower::ServiceExt;
+
+    const ALLOWED: &str = "http://localhost:5173";
+    const OTHER: &str = "https://evil.example";
+
+    fn origins() -> AllowedOrigins {
+        AllowedOrigins::new(vec![HeaderValue::from_static(ALLOWED)])
+    }
+
+    fn app() -> Router {
+        guard(
+            Router::new()
+                .route("/read", get(|| async { StatusCode::OK }))
+                .route("/mutate", post(|| async { StatusCode::NO_CONTENT })),
+            origins(),
+        )
+    }
+
+    fn request(method: &str, path: &str, headers: &[(&str, &str)]) -> Request<Body> {
+        let mut request = Request::builder().method(method).uri(path);
+        for (name, value) in headers {
+            request = request.header(*name, *value);
+        }
+        request.body(Body::empty()).unwrap()
+    }
+
+    async fn status_of(headers: &[(&str, &str)]) -> StatusCode {
+        app()
+            .oneshot(request("POST", "/mutate", headers))
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[test]
+    fn same_site_fetch_metadata_passes_whatever_the_origin() {
+        for site in ["same-origin", "same-site", "none"] {
+            for origin in [None, Some(ALLOWED), Some(OTHER)] {
+                let mut headers = HeaderMap::new();
+                headers.insert(SEC_FETCH_SITE, HeaderValue::from_static(site));
+                if let Some(origin) = origin {
+                    headers.insert(header::ORIGIN, HeaderValue::from_static(origin));
+                }
+
+                assert_eq!(
+                    verdict(&Method::POST, &headers, &origins()),
+                    Ok(()),
+                    "{site} with origin {origin:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cross_site_fetch_metadata_needs_an_allowed_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("cross-site"));
+        assert_eq!(
+            verdict(&Method::POST, &headers, &origins()),
+            Err(Rejection::CrossSite)
+        );
+
+        headers.insert(header::ORIGIN, HeaderValue::from_static(OTHER));
+        assert_eq!(
+            verdict(&Method::POST, &headers, &origins()),
+            Err(Rejection::CrossSite)
+        );
+
+        headers.insert(header::ORIGIN, HeaderValue::from_static(ALLOWED));
+        assert_eq!(verdict(&Method::POST, &headers, &origins()), Ok(()));
+    }
+
+    /// A `Sec-Fetch-Site` value this code has never heard of is treated like
+    /// `cross-site`: the safe reading of an unknown claim.
+    #[test]
+    fn an_unknown_fetch_site_value_is_treated_as_cross_site() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("other-planet"));
+        assert_eq!(
+            verdict(&Method::POST, &headers, &origins()),
+            Err(Rejection::CrossSite)
+        );
+
+        headers.insert(header::ORIGIN, HeaderValue::from_static(ALLOWED));
+        assert_eq!(verdict(&Method::POST, &headers, &origins()), Ok(()));
+    }
+
+    #[test]
+    fn without_fetch_metadata_the_origin_decides() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(verdict(&Method::POST, &headers, &origins()), Ok(()));
+
+        headers.insert(header::ORIGIN, HeaderValue::from_static(ALLOWED));
+        assert_eq!(verdict(&Method::POST, &headers, &origins()), Ok(()));
+
+        headers.insert(header::ORIGIN, HeaderValue::from_static(OTHER));
+        assert_eq!(
+            verdict(&Method::POST, &headers, &origins()),
+            Err(Rejection::UnknownOrigin)
+        );
+
+        // An opaque origin (sandboxed frame, redirect across origins, some
+        // privacy modes) is not an allowed one.
+        headers.insert(header::ORIGIN, HeaderValue::from_static("null"));
+        assert_eq!(
+            verdict(&Method::POST, &headers, &origins()),
+            Err(Rejection::UnknownOrigin)
+        );
+    }
+
+    #[test]
+    fn safe_methods_pass_from_anywhere() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("cross-site"));
+        headers.insert(header::ORIGIN, HeaderValue::from_static(OTHER));
+
+        for method in [Method::GET, Method::HEAD, Method::OPTIONS] {
+            assert_eq!(verdict(&method, &headers, &origins()), Ok(()), "{method}");
+        }
+        for method in [Method::POST, Method::PUT, Method::PATCH, Method::DELETE] {
+            assert_eq!(
+                verdict(&method, &headers, &origins()),
+                Err(Rejection::CrossSite),
+                "{method}"
+            );
+        }
+    }
+
+    #[test]
+    fn origin_comparison_is_exact() {
+        let origins = origins();
+        for origin in [
+            "http://localhost:5173/",
+            "HTTP://localhost:5173",
+            "http://localhost:5173.evil.example",
+            "https://localhost:5173",
+        ] {
+            assert!(
+                !origins.contains(&HeaderValue::from_static(origin)),
+                "{origin} must not match {ALLOWED}"
+            );
+        }
+    }
+
+    /// A cross-site HTML form: `Sec-Fetch-Site: cross-site`, an `Origin` of
+    /// the attacking page, and the cookie that `SameSite=Lax` would have
+    /// withheld anyway. The layer answers before the handler runs.
+    #[tokio::test]
+    async fn a_cross_site_form_post_is_forbidden_with_the_standard_error_shape() {
+        let response = app()
+            .oneshot(request(
+                "POST",
+                "/mutate",
+                &[
+                    (SEC_FETCH_SITE, "cross-site"),
+                    ("sec-fetch-mode", "navigate"),
+                    ("origin", OTHER),
+                    ("content-type", "application/x-www-form-urlencoded"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "cross_site_request");
+    }
+
+    /// `fetch` from the development frontend: the API is on another port,
+    /// so the browser reports `cross-site` (localhost ports are different
+    /// sites only by scheme and host, but the header says what it says)
+    /// with the frontend's `Origin`. In production, served from a sibling
+    /// subdomain, the same call is `same-site`.
+    #[tokio::test]
+    async fn a_fetch_from_the_frontend_passes() {
+        assert_eq!(
+            status_of(&[(SEC_FETCH_SITE, "cross-site"), ("origin", ALLOWED)]).await,
+            StatusCode::NO_CONTENT
+        );
+        assert_eq!(
+            status_of(&[(SEC_FETCH_SITE, "same-site"), ("origin", ALLOWED)]).await,
+            StatusCode::NO_CONTENT
+        );
+    }
+
+    /// curl, a server-side client, a browser from before Fetch Metadata.
+    #[tokio::test]
+    async fn a_request_without_fetch_metadata_or_origin_passes() {
+        assert_eq!(status_of(&[]).await, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn a_get_from_anywhere_is_untouched() {
+        let response = app()
+            .oneshot(request(
+                "GET",
+                "/read",
+                &[(SEC_FETCH_SITE, "cross-site"), ("origin", OTHER)],
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// The layer also covers what the router does not know: a cross-site
+    /// probe of an unknown path is told nothing but 403.
+    #[tokio::test]
+    async fn the_fallback_is_guarded_too() {
+        let response = app()
+            .oneshot(request(
+                "POST",
+                "/nowhere",
+                &[(SEC_FETCH_SITE, "cross-site"), ("origin", OTHER)],
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/apps/cas/src/http/fetch_metadata.rs
+++ b/apps/cas/src/http/fetch_metadata.rs
@@ -66,7 +66,8 @@ async fn reject_cross_site(
 /// response is the same 403 whatever the reason.
 #[derive(Debug, PartialEq, Eq)]
 enum Rejection {
-    /// `Sec-Fetch-Site` names another site and `Origin` is not an allowed one.
+    /// `Sec-Fetch-Site` names another origin and `Origin` is not an allowed
+    /// one.
     CrossSite,
     /// No Fetch Metadata, and an `Origin` that is not an allowed one.
     UnknownOrigin,
@@ -85,9 +86,10 @@ impl Rejection {
 ///
 /// Safe methods always pass: `GET` navigations from other sites are how the
 /// future OIDC `/authorize` arrives, and a safe method changes nothing. For
-/// the rest, `Sec-Fetch-Site` is the authority when present: `same-origin`,
-/// `same-site` and `none` (a user-initiated request) pass; `cross-site`, and
-/// any value this code does not know, passes only with an allowed `Origin`.
+/// the rest, `Sec-Fetch-Site` is the authority when present: `same-origin`
+/// and `none` (a user-initiated request) pass; `same-site`, `cross-site`,
+/// and any value this code does not know, pass only with an allowed
+/// `Origin`. A sibling subdomain is same-site and still another party.
 /// Without Fetch Metadata the request is an old browser or a non-browser
 /// client, and `Origin` decides alone: absent or allowed passes.
 fn verdict(
@@ -106,7 +108,7 @@ fn verdict(
     };
 
     match headers.get(SEC_FETCH_SITE).map(HeaderValue::as_bytes) {
-        Some(b"same-origin" | b"same-site" | b"none") => Ok(()),
+        Some(b"same-origin" | b"none") => Ok(()),
         Some(_) if origin_allowed() => Ok(()),
         Some(_) => Err(Rejection::CrossSite),
         None if headers.get(header::ORIGIN).is_none() || origin_allowed() => Ok(()),
@@ -157,8 +159,8 @@ mod tests {
     }
 
     #[test]
-    fn same_site_fetch_metadata_passes_whatever_the_origin() {
-        for site in ["same-origin", "same-site", "none"] {
+    fn same_origin_and_user_initiated_requests_pass_whatever_the_origin() {
+        for site in ["same-origin", "none"] {
             for origin in [None, Some(ALLOWED), Some(OTHER)] {
                 let mut headers = HeaderMap::new();
                 headers.insert(SEC_FETCH_SITE, HeaderValue::from_static(site));
@@ -175,23 +177,34 @@ mod tests {
         }
     }
 
+    /// `same-site` is held to the same rule as `cross-site`: a sibling
+    /// subdomain shares the cookie jar (`SameSite=Lax` does not stop it) but
+    /// is not this service, so only the origin list admits it.
     #[test]
-    fn cross_site_fetch_metadata_needs_an_allowed_origin() {
-        let mut headers = HeaderMap::new();
-        headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("cross-site"));
-        assert_eq!(
-            verdict(&Method::POST, &headers, &origins()),
-            Err(Rejection::CrossSite)
-        );
+    fn same_site_and_cross_site_fetch_metadata_need_an_allowed_origin() {
+        for site in ["same-site", "cross-site"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(SEC_FETCH_SITE, HeaderValue::from_static(site));
+            assert_eq!(
+                verdict(&Method::POST, &headers, &origins()),
+                Err(Rejection::CrossSite),
+                "{site} without origin"
+            );
 
-        headers.insert(header::ORIGIN, HeaderValue::from_static(OTHER));
-        assert_eq!(
-            verdict(&Method::POST, &headers, &origins()),
-            Err(Rejection::CrossSite)
-        );
+            headers.insert(header::ORIGIN, HeaderValue::from_static(OTHER));
+            assert_eq!(
+                verdict(&Method::POST, &headers, &origins()),
+                Err(Rejection::CrossSite),
+                "{site} with a foreign origin"
+            );
 
-        headers.insert(header::ORIGIN, HeaderValue::from_static(ALLOWED));
-        assert_eq!(verdict(&Method::POST, &headers, &origins()), Ok(()));
+            headers.insert(header::ORIGIN, HeaderValue::from_static(ALLOWED));
+            assert_eq!(
+                verdict(&Method::POST, &headers, &origins()),
+                Ok(()),
+                "{site} with an allowed origin"
+            );
+        }
     }
 
     /// A `Sec-Fetch-Site` value this code has never heard of is treated like
@@ -291,20 +304,35 @@ mod tests {
         assert_eq!(body["error"]["code"], "cross_site_request");
     }
 
-    /// `fetch` from the development frontend: the API is on another port,
-    /// so the browser reports `cross-site` (localhost ports are different
-    /// sites only by scheme and host, but the header says what it says)
-    /// with the frontend's `Origin`. In production, served from a sibling
-    /// subdomain, the same call is `same-site`.
+    /// `fetch` from the frontend with its `Origin`. In development the API
+    /// is on another port of the same host, which browsers report as
+    /// `same-site`; a frontend on a sibling subdomain in production is
+    /// `same-site` too, and one on another domain is `cross-site`. The
+    /// origin list admits all three.
     #[tokio::test]
     async fn a_fetch_from_the_frontend_passes() {
+        for site in ["same-site", "cross-site"] {
+            assert_eq!(
+                status_of(&[(SEC_FETCH_SITE, site), ("origin", ALLOWED)]).await,
+                StatusCode::NO_CONTENT,
+                "{site}"
+            );
+        }
+    }
+
+    /// A form on a sibling subdomain: the browser sends `same-site` and the
+    /// session cookie, and the sibling is not in the origin list.
+    #[tokio::test]
+    async fn a_same_site_form_post_from_a_sibling_subdomain_is_forbidden() {
         assert_eq!(
-            status_of(&[(SEC_FETCH_SITE, "cross-site"), ("origin", ALLOWED)]).await,
-            StatusCode::NO_CONTENT
-        );
-        assert_eq!(
-            status_of(&[(SEC_FETCH_SITE, "same-site"), ("origin", ALLOWED)]).await,
-            StatusCode::NO_CONTENT
+            status_of(&[
+                (SEC_FETCH_SITE, "same-site"),
+                ("sec-fetch-mode", "navigate"),
+                ("origin", "https://blog.example.test"),
+                ("content-type", "application/x-www-form-urlencoded"),
+            ])
+            .await,
+            StatusCode::FORBIDDEN
         );
     }
 

--- a/apps/cas/src/http/mod.rs
+++ b/apps/cas/src/http/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod error;
 pub(crate) mod extract;
+mod fetch_metadata;
 mod health;
 
 use axum::{
@@ -23,6 +24,7 @@ use tracing::Level;
 
 use crate::config::Config;
 use crate::http::error::ApiError;
+use crate::http::fetch_metadata::AllowedOrigins;
 use crate::sessions::SessionService;
 use crate::sessions::http as sessions_http;
 use crate::sessions::http::CookieSettings;
@@ -70,12 +72,23 @@ pub fn app(config: Config) -> Result<Router, AppError> {
         cookies: CookieSettings::for_origin(&config.origin),
     };
 
-    let router = Router::new()
-        .merge(health::router(pool))
-        .nest("/api/webauthn", webauthn_http::router(api_state.clone()))
-        .nest("/api", sessions_http::router(api_state));
+    let router = Router::new().merge(health::router(pool)).nest(
+        "/api",
+        api_router(api_state, AllowedOrigins::new(config.cors_origins.clone())),
+    );
 
     Ok(with_middleware(router, config.cors_origins))
+}
+
+/// Everything under `/api`: the contexts' routers behind the CSRF line
+/// (ADR 0005). `/health` stays outside: it is read-only and probed by
+/// machines that send no browser headers.
+fn api_router(state: ApiState, origins: AllowedOrigins) -> Router {
+    let api = Router::new()
+        .nest("/webauthn", webauthn_http::router(state.clone()))
+        .merge(sessions_http::router(state));
+
+    fetch_metadata::guard(api, origins)
 }
 
 /// Applies the middleware stack. Must be called after all routes are
@@ -134,9 +147,16 @@ mod tests {
         http::{Request, StatusCode, header},
         routing::get,
     };
+    use sqlx::PgPool;
     use tower::ServiceExt;
 
+    use crate::accounts::{AccountRepository, NewAccount};
+    use crate::sessions::SessionService;
+    use crate::sessions::http::cookie::SESSION_COOKIE;
+    use crate::testing::{display_name, test_state};
+
     const ALLOWED_ORIGIN: &str = "http://localhost:5173";
+    const OTHER_ORIGIN: &str = "https://evil.example";
 
     fn test_config() -> Config {
         Config {
@@ -213,6 +233,128 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(login.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    fn allowed_origins() -> AllowedOrigins {
+        AllowedOrigins::new(vec![HeaderValue::from_static(ALLOWED_ORIGIN)])
+    }
+
+    async fn signed_in(pool: &PgPool) -> String {
+        let account = AccountRepository::new(pool.clone())
+            .create(NewAccount::full(display_name("Ada")))
+            .await
+            .unwrap();
+        let issued = SessionService::new(pool.clone())
+            .create(account.id)
+            .await
+            .unwrap();
+        format!("{SESSION_COOKIE}={}", issued.token.expose())
+    }
+
+    /// The gap ADR 0004 left open: a cross-site HTML form posting to the
+    /// body-less logout with the victim's cookie. The layer refuses it and
+    /// the session is still there.
+    #[sqlx::test]
+    async fn a_cross_site_form_post_to_logout_is_forbidden_and_keeps_the_session(pool: PgPool) {
+        let cookie = signed_in(&pool).await;
+        let app = api_router(test_state(pool), allowed_origins());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/logout")
+                    .header("sec-fetch-site", "cross-site")
+                    .header("sec-fetch-mode", "navigate")
+                    .header(header::ORIGIN, OTHER_ORIGIN)
+                    .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .header(header::COOKIE, &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(
+            !response.headers().contains_key(header::SET_COOKIE),
+            "a refused request must not touch the cookie"
+        );
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["code"], "cross_site_request");
+
+        let me = app
+            .oneshot(
+                Request::builder()
+                    .uri("/me")
+                    .header(header::COOKIE, &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(me.status(), StatusCode::OK, "the session must survive");
+    }
+
+    /// The frontend's own `fetch` with credentials reaches the handler.
+    #[sqlx::test]
+    async fn a_fetch_from_the_frontend_logs_out(pool: PgPool) {
+        let cookie = signed_in(&pool).await;
+
+        let response = api_router(test_state(pool), allowed_origins())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/logout")
+                    .header("sec-fetch-site", "cross-site")
+                    .header("sec-fetch-mode", "cors")
+                    .header(header::ORIGIN, ALLOWED_ORIGIN)
+                    .header(header::COOKIE, &cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    /// Both nested routers sit behind the layer, and a `GET` is not its
+    /// business: `/api/me` from another site answers 401 for the missing
+    /// session, not 403.
+    #[tokio::test]
+    async fn every_api_route_is_behind_the_csrf_line_but_gets_pass() {
+        let app = app(test_config()).unwrap();
+        let cross_site = |method: &str, uri: &str| {
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("sec-fetch-site", "cross-site")
+                .header(header::ORIGIN, OTHER_ORIGIN)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap()
+        };
+
+        for uri in ["/api/logout", "/api/webauthn/verify-login"] {
+            let response = app.clone().oneshot(cross_site("POST", uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{uri}");
+        }
+
+        let me = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/me")
+                    .header("sec-fetch-site", "cross-site")
+                    .header(header::ORIGIN, OTHER_ORIGIN)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(me.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #696.

## What

- `src/http/fetch_metadata.rs`: a layer on the `/api` router that refuses a mutating request (anything but `GET`/`HEAD`/`OPTIONS`) unless
  - `Sec-Fetch-Site` is `same-origin` or `none`; or
  - `Sec-Fetch-Site` is `same-site`, `cross-site` (or any unknown value) and `Origin` is in `CAS_CORS_ORIGINS`; or
  - `Sec-Fetch-Site` is absent and `Origin` is absent or in `CAS_CORS_ORIGINS`.
- `same-site` is held to the origin list because a sibling subdomain shares the cookie jar and can post an HTML form that no CORS preflight sees (review finding).
- Refusal: `403 cross_site_request`, standard `ApiError` shape, before the handler and before any DB access. Reason logged at `warn` with method, path and both headers.
- `ApiError::forbidden` constructor.
- `/api` is now built as one router (`api_router`) and wrapped by the layer before being nested, so every route and the fallback under it are covered. `/health` stays outside.
- ADR 0005 records the decision and the fallback rules; ADR 0004 (e) and its consequences point at it. `docs/LAYOUT.md` lists the new file.

## Tests

- Pure `verdict` tests for each branch: same-origin/none, same-site and cross-site with/without allowed origin, unknown `Sec-Fetch-Site` value, no Fetch Metadata with absent/allowed/other/`null` origin, safe vs. mutating methods, exact origin comparison.
- Router tests: cross-site form `POST /logout` with a valid cookie → 403, no `Set-Cookie`, session still answers `/me`; same-site form from a sibling subdomain → 403; `fetch` from the allowed origin logs out; request without any headers passes; `GET` from anywhere untouched; both nested contexts are behind the layer; the fallback is guarded.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` and `cargo test` (147 tests, against the dev Postgres) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)