### PR TITLE
feat(cas): idle timeout with sliding renewal for sessions (#697)

### DIFF
--- a/apps/cas/.sqlx/query-23a054955b2f55cce14164c2081966497e1e808394e91af99e5637221154c287.json
+++ b/apps/cas/.sqlx/query-23a054955b2f55cce14164c2081966497e1e808394e91af99e5637221154c287.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "UPDATE sessions SET last_seen_at = now() WHERE id = $1 RETURNING last_seen_at",
+  "query": "UPDATE sessions SET last_seen_at = now()\n           WHERE id = $1 AND last_seen_at <= now() - make_interval(secs => $2)\n           RETURNING last_seen_at",
   "describe": {
     "columns": [
       {
@@ -17,12 +17,13 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "Uuid",
+        "Float8"
       ]
     },
     "nullable": [
       false
     ]
   },
-  "hash": "c935d10d0dc39d07738550cb5e418a8a71ce2b0a5b9bb4bd2eaf24bff3bd5831"
+  "hash": "23a054955b2f55cce14164c2081966497e1e808394e91af99e5637221154c287"
 }

--- a/apps/cas/.sqlx/query-c935d10d0dc39d07738550cb5e418a8a71ce2b0a5b9bb4bd2eaf24bff3bd5831.json
+++ b/apps/cas/.sqlx/query-c935d10d0dc39d07738550cb5e418a8a71ce2b0a5b9bb4bd2eaf24bff3bd5831.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE sessions SET last_seen_at = now() WHERE id = $1 RETURNING last_seen_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_seen_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "last_seen_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c935d10d0dc39d07738550cb5e418a8a71ce2b0a5b9bb4bd2eaf24bff3bd5831"
+}

--- a/apps/cas/.sqlx/query-d959a86751b33822ea19aa36e09d612f348c493eebe87460738644c58ab5e8b3.json
+++ b/apps/cas/.sqlx/query-d959a86751b33822ea19aa36e09d612f348c493eebe87460738644c58ab5e8b3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT id, account_id, created_at, expires_at\n           FROM sessions\n           WHERE token_hash = $1 AND expires_at > now()",
+  "query": "SELECT id, account_id, created_at, expires_at, last_seen_at,\n                  last_seen_at <= now() - make_interval(secs => $3) AS \"renewal_due!\"\n           FROM sessions\n           WHERE token_hash = $1\n             AND expires_at > now()\n             AND last_seen_at > now() - make_interval(secs => $2)",
   "describe": {
     "columns": [
       {
@@ -46,19 +46,40 @@
             "name": "expires_at"
           }
         }
+      },
+      {
+        "ordinal": 4,
+        "name": "last_seen_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "last_seen_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "renewal_due!",
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {
       "Left": [
-        "Bytea"
+        "Bytea",
+        "Float8",
+        "Float8"
       ]
     },
     "nullable": [
       false,
       false,
       false,
-      false
+      false,
+      false,
+      null
     ]
   },
-  "hash": "b3d44a5b7f19cd4b66457c60ed8430208b533ff3d22388463c35319755016d38"
+  "hash": "d959a86751b33822ea19aa36e09d612f348c493eebe87460738644c58ab5e8b3"
 }

--- a/apps/cas/.sqlx/query-ddebd0ed71d696985ddb67ffbd68582c3abfd9f533f157681d22c528cd038cae.json
+++ b/apps/cas/.sqlx/query-ddebd0ed71d696985ddb67ffbd68582c3abfd9f533f157681d22c528cd038cae.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO sessions (account_id, token_hash, expires_at)\n           VALUES ($1, $2, now() + make_interval(secs => $3))\n           RETURNING id, account_id, created_at, expires_at",
+  "query": "INSERT INTO sessions (account_id, token_hash, expires_at)\n           VALUES ($1, $2, now() + make_interval(secs => $3))\n           RETURNING id, account_id, created_at, expires_at, last_seen_at",
   "describe": {
     "columns": [
       {
@@ -46,6 +46,17 @@
             "name": "expires_at"
           }
         }
+      },
+      {
+        "ordinal": 4,
+        "name": "last_seen_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "last_seen_at"
+          }
+        }
       }
     ],
     "parameters": {
@@ -59,8 +70,9 @@
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "fda75993d329970fc735b19d6557e74d1ced52e66e6a0c4d46b695cfcce3cfdd"
+  "hash": "ddebd0ed71d696985ddb67ffbd68582c3abfd9f533f157681d22c528cd038cae"
 }

--- a/apps/cas/docs/adr/0004-cookie-sessions.md
+++ b/apps/cas/docs/adr/0004-cookie-sessions.md
@@ -3,6 +3,8 @@
 ## Status
 
 Accepted (2026-09-12), with [#667](https://github.com/MemeBattle/monorepo/issues/667).
+Amended (2026-09-12) by [#697](https://github.com/MemeBattle/monorepo/issues/697):
+decision (c) gained an idle timeout with sliding renewal.
 
 ## Context
 
@@ -28,19 +30,35 @@ the table, in a backup or over the shoulder in `psql`, does not hand out live
 sessions. Lookup is by the hash, which is the unique column. The token exists
 in memory only between its generation and the response that sets the cookie.
 
-**(c) Expiry is absolute, 30 days, measured by the database clock.** The
-cookie's `Max-Age` and the row's `expires_at` are derived from the same
-constant, so the browser and the server give up together. A sliding expiry
-would cost a write on every authenticated request; it can be added when a
-product need appears. Expired rows are not returned and are not removed by
-the application: like `webauthn_ceremonies`, cleanup is a scheduled job, never
-part of the request path.
+**(c) Two clocks, both the database's: an idle timeout of 7 days with
+sliding renewal, under an absolute cap of 30 days.** The row's `expires_at`
+is fixed at creation and never moves; `last_seen_at` is reset by an
+authenticated request, and a session is live only while it is before the cap
+and was seen within the idle timeout. Renewal is not a write per request: a
+request inside the renewal window (one hour) after the last reset writes
+nothing, one outside it resets the clock and moves the account's
+`last_seen_at` with it, in one transaction, as at creation. A session's real
+idle limit is therefore between seven days and seven days plus an hour, and
+a session in constant use costs one write an hour. The cookie's `Max-Age`
+runs to the moment the session stops being honoured if nothing renews it,
+the idle timeout or the cap, whichever is first, and a renewal re-sends the
+cookie with the clock pushed out, so the browser and the server give up
+together, as before. Expired rows of either kind are not returned and are
+not removed by the application: like `webauthn_ceremonies`, cleanup is a
+scheduled job, never part of the request path.
 
-This is longer than the OWASP Session Management guidance (an idle timeout on
-top of an absolute one, and a non-persistent cookie). Whether a game SSO
-justifies it is decided in
-[#697](https://github.com/MemeBattle/monorepo/issues/697); this ADR is amended
-with the outcome.
+The first version of this decision had one absolute clock of 30 days and no
+idle timeout, on the grounds that a sliding expiry costs a write on every
+request. The OWASP Session Management guidance asks for an idle timeout on
+top of an absolute one, and the objection falls once renewal is rate limited
+by the window. Seven days is long for OWASP and short for a game: it is what
+a player who opens the game most weeks never notices, and a passkey makes
+signing in again a single touch rather than a password to remember, which is
+what makes a shorter idle limit affordable here. The cap stays at 30 days as
+the bound on how long a stolen cookie is worth anything, however active the
+thief. The cookie stays persistent (`Max-Age` rather than a session cookie):
+a game's players close the tab between rounds, and a non-persistent cookie
+would sign them out every time.
 
 **(d) The cookie is `HttpOnly`, `SameSite=Lax`, `Path=/`, host-only, and
 `Secure` when the relying party origin is https.** `HttpOnly`: script never
@@ -83,26 +101,38 @@ whether or not a row was found.
 **(h) `Authenticated` is an axum extractor.** A handler that takes one runs
 only for a request with a live session and receives the session and the
 account; the 401 happens before the handler. It lives in the sessions
-context's transport and is the one thing other contexts import from it.
+context's transport and is the one thing other contexts import from it. The
+extractor is also where renewal happens, and since an extractor cannot touch
+the response, a layer on the `/api` router carries the renewed cookie out:
+the extractor leaves it in a per-request slot, the layer sets it on the way
+back. A handler that sets the session cookie itself wins over the layer.
 
 ## Consequences
 
 - `GET /api/me` answers with the account (id, display name, type, email) and
-  the session's expiry, nothing else about the session.
+  when the session ends if left alone (the idle timeout from its last reset,
+  or the cap, whichever is first), nothing else about the session.
 - A session outlives a passkey: deleting a credential (#668) does not end the
   sessions that were opened with it. Ending them is an explicit act, and a
   "sign out everywhere" belongs with session listing, later.
 - Every authenticated request costs two reads: the session by hash, then the
   account by id. A join would save one round trip and put another context's
-  columns in this context's SQL; the round trip is the cheaper price.
+  columns in this context's SQL; the round trip is the cheaper price. A
+  request that renews the session adds one transaction with two writes, at
+  most once an hour per session.
 - The `sessions` table grows by one row per sign-in and per expired session
-  until the scheduled cleanup exists; the index on `expires_at` is there for
-  it.
+  until the scheduled cleanup exists; the indexes on `expires_at` and
+  `last_seen_at` are there for it, and it must delete rows past either
+  clock.
+- Renewal makes `last_seen_at` on `sessions` and on `accounts` move
+  together, so account activity for guest GC (M2) is as fresh as the
+  renewal window, not as fresh as the last sign-in.
 - The session id is the row's identity for the future management screen; the
   token never identifies a session anywhere but in the lookup.
 - Hardening that OWASP recommends and this change leaves out is tracked
   separately: the CSRF layer ([#696](https://github.com/MemeBattle/monorepo/issues/696),
-  done in ADR 0005), the timeout decision ([#697](https://github.com/MemeBattle/monorepo/issues/697)),
+  done in ADR 0005), the timeout decision ([#697](https://github.com/MemeBattle/monorepo/issues/697),
+  done in (c) above),
   `Cache-Control: no-store` and `Clear-Site-Data`
   ([#698](https://github.com/MemeBattle/monorepo/issues/698)), session
   lifecycle logging ([#699](https://github.com/MemeBattle/monorepo/issues/699))

--- a/apps/cas/docs/adr/0004-cookie-sessions.md
+++ b/apps/cas/docs/adr/0004-cookie-sessions.md
@@ -37,9 +37,13 @@ authenticated request, and a session is live only while it is before the cap
 and was seen within the idle timeout. Renewal is not a write per request: a
 request inside the renewal window (one hour) after the last reset writes
 nothing, one outside it resets the clock and moves the account's
-`last_seen_at` with it, in one transaction, as at creation. A session's real
-idle limit is therefore between seven days and seven days plus an hour, and
-a session in constant use costs one write an hour. The cookie's `Max-Age`
+`last_seen_at` with it, in one transaction, as at creation. The clock lags
+the last request by up to an hour, so measured from that request a session
+ends between seven days less an hour and seven days, and a session in
+constant use costs one write an hour. The write checks the window again
+itself: two requests that both read the clock as due renew it once, the
+second finding nothing to do, and a request whose session logout removed in
+between is unauthenticated, not an error. The cookie's `Max-Age`
 runs to the moment the session stops being honoured if nothing renews it,
 the idle timeout or the cap, whichever is first, and a renewal re-sends the
 cookie with the clock pushed out, so the browser and the server give up

--- a/apps/cas/migrations/20260912170827_sessions_last_seen_at.sql
+++ b/apps/cas/migrations/20260912170827_sessions_last_seen_at.sql
@@ -1,0 +1,13 @@
+-- Idle timeout for sessions (ADR 0004, amended with #697).
+--
+-- A session now has two clocks: `expires_at`, the absolute cap fixed at
+-- creation, and `last_seen_at`, reset by an authenticated request at most
+-- once per renewal window. A row is live only while both hold. Existing rows
+-- start their idle clock now; nothing is signed out by this migration.
+
+ALTER TABLE sessions
+    ADD COLUMN last_seen_at timestamptz NOT NULL DEFAULT now();
+
+-- For the scheduled cleanup of idle-expired rows, next to the index on
+-- expires_at that serves the absolute ones.
+CREATE INDEX sessions_last_seen_at_idx ON sessions (last_seen_at);

--- a/apps/cas/src/http/mod.rs
+++ b/apps/cas/src/http/mod.rs
@@ -80,15 +80,16 @@ pub fn app(config: Config) -> Result<Router, AppError> {
     Ok(with_middleware(router, config.cors_origins))
 }
 
-/// Everything under `/api`: the contexts' routers behind the CSRF line
-/// (ADR 0005). `/health` stays outside: it is read-only and probed by
+/// Everything under `/api`: the contexts' routers, re-sending the session
+/// cookie when a request renewed its session (ADR 0004), behind the CSRF
+/// line (ADR 0005). `/health` stays outside: it is read-only and probed by
 /// machines that send no browser headers.
 fn api_router(state: ApiState, origins: AllowedOrigins) -> Router {
     let api = Router::new()
         .nest("/webauthn", webauthn_http::router(state.clone()))
         .merge(sessions_http::router(state));
 
-    fetch_metadata::guard(api, origins)
+    fetch_metadata::guard(sessions_http::with_cookie_renewal(api), origins)
 }
 
 /// Applies the middleware stack. Must be called after all routes are

--- a/apps/cas/src/sessions/http/cookie.rs
+++ b/apps/cas/src/sessions/http/cookie.rs
@@ -1,9 +1,10 @@
 //! The session cookie: the one place its name and attributes are decided.
 
 use axum_extra::extract::cookie::{Cookie, SameSite};
+use time::OffsetDateTime;
 use webauthn_rs::prelude::Url;
 
-use crate::sessions::{SESSION_LIFETIME, SessionToken};
+use crate::sessions::{Session, SessionToken};
 
 /// The cookie's name. The `cas_` prefix keeps it apart from anything another
 /// app on the same site might set.
@@ -26,17 +27,19 @@ impl CookieSettings {
         }
     }
 
-    /// The cookie that carries a freshly issued session.
+    /// The cookie that carries a session: sent when it is issued and again
+    /// each time it is renewed.
     ///
     /// `HttpOnly`: script never reads it. `SameSite=Lax`: sent on top-level
     /// navigations (the future OIDC `/authorize` redirect must carry it) but
     /// not on cross-site POSTs, which is the CSRF line. `Path=/`: one cookie
-    /// for the whole service. `Max-Age`: the same lifetime the row has.
-    pub fn session(&self, token: &SessionToken) -> Cookie<'static> {
+    /// for the whole service. `Max-Age`: until the session stops being
+    /// honoured if nothing renews it, so the browser and the server give up
+    /// together; a renewal re-sends the cookie with the clock pushed out.
+    pub fn session(&self, token: &SessionToken, session: &Session) -> Cookie<'static> {
         let mut cookie = self.base(token.expose().to_owned());
         cookie.set_max_age(
-            time::Duration::try_from(SESSION_LIFETIME)
-                .expect("the session lifetime fits in a cookie max-age"),
+            (session.valid_until() - OffsetDateTime::now_utc()).max(time::Duration::ZERO),
         );
         cookie
     }
@@ -63,6 +66,8 @@ impl CookieSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sessions::{SESSION_IDLE_TIMEOUT, SESSION_LIFETIME, as_time};
+    use uuid::Uuid;
 
     fn origin(value: &str) -> Url {
         value.parse().unwrap()
@@ -74,12 +79,24 @@ mod tests {
         assert!(!CookieSettings::for_origin(&origin("http://localhost:5173")).secure);
     }
 
+    /// A session as `create` would return it right now.
+    fn fresh_session() -> Session {
+        let now = OffsetDateTime::now_utc();
+        Session {
+            id: Uuid::new_v4(),
+            account_id: Uuid::new_v4(),
+            created_at: now,
+            expires_at: now + as_time(SESSION_LIFETIME),
+            last_seen_at: now,
+        }
+    }
+
     #[test]
     fn the_session_cookie_is_locked_down() {
         let token = SessionToken::generate().unwrap();
         let settings = CookieSettings { secure: true };
 
-        let cookie = settings.session(&token);
+        let cookie = settings.session(&token, &fresh_session());
 
         assert_eq!(cookie.name(), SESSION_COOKIE);
         assert_eq!(cookie.value(), token.expose());
@@ -88,9 +105,34 @@ mod tests {
         assert_eq!(cookie.same_site(), Some(SameSite::Lax));
         assert_eq!(cookie.path(), Some("/"));
         assert_eq!(cookie.domain(), None, "host-only");
+    }
+
+    /// The browser drops the cookie when the server would stop honouring the
+    /// session: the idle timeout for a fresh session, the cap when that is
+    /// nearer, never less than nothing.
+    #[test]
+    fn max_age_follows_the_session_clocks() {
+        let token = SessionToken::generate().unwrap();
+        let settings = CookieSettings { secure: true };
+        let idle = as_time(SESSION_IDLE_TIMEOUT);
+        let slack = time::Duration::seconds(5);
+
+        let fresh = settings
+            .session(&token, &fresh_session())
+            .max_age()
+            .unwrap();
+        assert!(fresh <= idle && fresh > idle - slack, "{fresh}");
+
+        let mut near_the_cap = fresh_session();
+        near_the_cap.expires_at = near_the_cap.last_seen_at + time::Duration::days(1);
+        let capped = settings.session(&token, &near_the_cap).max_age().unwrap();
+        assert!(capped <= time::Duration::days(1) && capped > time::Duration::days(1) - slack);
+
+        let mut over = fresh_session();
+        over.expires_at = over.last_seen_at - time::Duration::seconds(1);
         assert_eq!(
-            cookie.max_age(),
-            Some(time::Duration::try_from(SESSION_LIFETIME).unwrap())
+            settings.session(&token, &over).max_age(),
+            Some(time::Duration::ZERO)
         );
     }
 

--- a/apps/cas/src/sessions/http/extract.rs
+++ b/apps/cas/src/sessions/http/extract.rs
@@ -1,6 +1,10 @@
 //! The `Authenticated` extractor: a handler that takes one runs only for a
 //! request carrying a live session cookie, and gets the session and the
 //! account. Everything else is a 401 before the handler is entered.
+//!
+//! When authenticating renewed the session, the extractor leaves the fresh
+//! cookie in the request's [`renewal`] slot for the layer to put on the
+//! response; the handler never sees it.
 
 use axum::extract::{FromRef, FromRequestParts};
 use axum::http::request::Parts;
@@ -9,7 +13,8 @@ use axum_extra::extract::CookieJar;
 use crate::http::ApiState;
 use crate::http::error::ApiError;
 use crate::sessions::http::cookie::SESSION_COOKIE;
-use crate::sessions::{Authenticated, SessionToken};
+use crate::sessions::http::renewal::{self, RenewalSlot};
+use crate::sessions::{Authenticated, Renewal, SessionToken};
 
 /// One code for every way a request can fail to be authenticated — no
 /// cookie, a malformed one, an unknown, expired or revoked session — so a
@@ -39,10 +44,18 @@ where
             .and_then(|cookie| SessionToken::parse(cookie.value()))
             .ok_or_else(unauthenticated)?;
 
-        state
+        let (authenticated, renewal) = state
             .sessions
             .authenticate(&token)
             .await?
-            .ok_or_else(unauthenticated)
+            .ok_or_else(unauthenticated)?;
+
+        if renewal == Renewal::Renewed
+            && let Some(slot) = parts.extensions.get::<RenewalSlot>()
+        {
+            renewal::offer(slot, state.cookies.session(&token, &authenticated.session));
+        }
+
+        Ok(authenticated)
     }
 }

--- a/apps/cas/src/sessions/http/mod.rs
+++ b/apps/cas/src/sessions/http/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod cookie;
 pub mod extract;
+pub mod renewal;
 
 use axum::{Json, Router, extract::State, http::StatusCode, routing::get, routing::post};
 use axum_extra::extract::CookieJar;
@@ -19,6 +20,7 @@ use crate::sessions::service::CreateError;
 use crate::sessions::{Authenticated, SessionToken};
 
 pub use cookie::CookieSettings;
+pub use renewal::with_cookie_renewal;
 
 /// Registration and login create sessions from their own handlers; the
 /// mapping lives here, with the context that owns the error.
@@ -41,7 +43,8 @@ pub fn router(state: ApiState) -> Router {
 }
 
 /// The signed-in account as the dashboard needs it. Nothing about the
-/// session itself but its expiry: the id is server-side state.
+/// session itself but when it ends if left alone: the id is server-side
+/// state.
 #[derive(Debug, Serialize, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeResponse {
@@ -61,7 +64,7 @@ async fn me(authenticated: Authenticated) -> Json<MeResponse> {
         display_name: account.display_name.into_inner(),
         account_type: account.r#type,
         email: account.email,
-        session_expires_at: session.expires_at,
+        session_expires_at: session.valid_until(),
     })
 }
 

--- a/apps/cas/src/sessions/http/renewal.rs
+++ b/apps/cas/src/sessions/http/renewal.rs
@@ -1,0 +1,209 @@
+//! Re-sending the session cookie after a renewal.
+//!
+//! The `Authenticated` extractor (`extract`) is where a session's idle clock
+//! is reset, but an extractor cannot touch the response. This layer gives
+//! every request a [`RenewalSlot`]; the extractor drops the fresh cookie into
+//! it, and the layer adds it to the response on the way out. A handler that
+//! sets the cookie itself wins: the layer never adds a second `Set-Cookie`.
+
+use std::sync::{Arc, OnceLock};
+
+use axum::{
+    Router,
+    extract::Request,
+    http::header,
+    middleware::{self, Next},
+    response::Response,
+};
+use axum_extra::extract::cookie::Cookie;
+
+/// One per request, shared between the layer and the extractor through the
+/// request extensions. Written at most once: a request authenticates once.
+#[derive(Debug, Clone, Default)]
+pub struct RenewalSlot(Arc<OnceLock<Cookie<'static>>>);
+
+/// Leaves the cookie for the layer. A second offer on the same request is
+/// ignored; the first renewal is the one that happened.
+pub(super) fn offer(slot: &RenewalSlot, cookie: Cookie<'static>) {
+    let _ = slot.0.set(cookie);
+}
+
+/// Wraps a router so that a request whose session was renewed answers with
+/// the fresh cookie. Applied by the transport root to everything under
+/// `/api`: any handler there may take `Authenticated`.
+pub fn with_cookie_renewal(router: Router) -> Router {
+    router.layer(middleware::from_fn(renew_cookie))
+}
+
+async fn renew_cookie(mut request: Request, next: Next) -> Response {
+    let slot = RenewalSlot::default();
+    request.extensions_mut().insert(slot.clone());
+
+    let mut response = next.run(request).await;
+
+    if let Some(cookie) = slot.0.get()
+        && !response.headers().contains_key(header::SET_COOKIE)
+        && let Ok(value) = cookie.encoded().to_string().parse()
+    {
+        response.headers_mut().insert(header::SET_COOKIE, value);
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::{get, post},
+    };
+    use axum_extra::extract::CookieJar;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::accounts::{AccountRepository, NewAccount};
+    use crate::http::ApiState;
+    use crate::sessions::http::cookie::SESSION_COOKIE;
+    use crate::sessions::{Authenticated, SESSION_IDLE_TIMEOUT, SessionService, as_time};
+    use crate::testing::{display_name, test_state};
+
+    async fn signed_in(pool: &PgPool) -> (Uuid, String) {
+        let account = AccountRepository::new(pool.clone())
+            .create(NewAccount::full(display_name("Ada")))
+            .await
+            .unwrap();
+        let issued = SessionService::new(pool.clone())
+            .create(account.id)
+            .await
+            .unwrap();
+        (
+            issued.session.id,
+            format!("{SESSION_COOKIE}={}", issued.token.expose()),
+        )
+    }
+
+    /// Moves a session's last use into the past by the given interval.
+    /// Unchecked query: see docs/TESTS.md.
+    async fn last_seen(pool: &PgPool, id: Uuid, ago: &str) {
+        sqlx::query("UPDATE sessions SET last_seen_at = now() - $2::interval WHERE id = $1")
+            .bind(id)
+            .bind(ago)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    async fn whoami(authenticated: Authenticated) -> String {
+        authenticated.account.id.to_string()
+    }
+
+    /// A handler that takes the session and also clears the cookie: what a
+    /// future "sign out everywhere" would do.
+    async fn sign_out(_authenticated: Authenticated, jar: CookieJar) -> (CookieJar, StatusCode) {
+        (
+            jar.add(Cookie::build((SESSION_COOKIE, "")).path("/").build()),
+            StatusCode::NO_CONTENT,
+        )
+    }
+
+    fn app(state: ApiState) -> Router {
+        with_cookie_renewal(
+            Router::new()
+                .route("/whoami", get(whoami))
+                .route("/sign-out", post(sign_out))
+                .with_state(state),
+        )
+    }
+
+    fn request(method: &str, uri: &str, cookie: &str) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::COOKIE, cookie)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn a_request_inside_the_window_gets_no_cookie(pool: PgPool) {
+        let (_, cookie) = signed_in(&pool).await;
+
+        let response = app(test_state(pool))
+            .oneshot(request("GET", "/whoami", &cookie))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(!response.headers().contains_key(header::SET_COOKIE));
+    }
+
+    /// The renewed session comes back to the browser with its `Max-Age`
+    /// pushed out to the idle timeout again, same token, same attributes.
+    #[sqlx::test]
+    async fn a_renewing_request_re_sends_the_cookie(pool: PgPool) {
+        let (id, cookie) = signed_in(&pool).await;
+        last_seen(&pool, id, "2 hours").await;
+
+        let response = app(test_state(pool))
+            .oneshot(request("GET", "/whoami", &cookie))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let set_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("a renewal re-sends the cookie")
+            .to_str()
+            .unwrap();
+        let sent = Cookie::parse(set_cookie).unwrap();
+        assert_eq!(format!("{SESSION_COOKIE}={}", sent.value()), cookie);
+        assert_eq!(sent.http_only(), Some(true));
+        assert_eq!(sent.path(), Some("/"));
+        let max_age = sent.max_age().unwrap();
+        let idle = as_time(SESSION_IDLE_TIMEOUT);
+        assert!(max_age <= idle && max_age > idle - time::Duration::seconds(5));
+    }
+
+    /// The handler's own `Set-Cookie` is the answer; the renewal cookie does
+    /// not compete with it.
+    #[sqlx::test]
+    async fn a_handler_that_sets_the_cookie_wins(pool: PgPool) {
+        let (id, cookie) = signed_in(&pool).await;
+        last_seen(&pool, id, "2 hours").await;
+
+        let response = app(test_state(pool))
+            .oneshot(request("POST", "/sign-out", &cookie))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let set_cookies: Vec<_> = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .collect();
+        assert_eq!(set_cookies.len(), 1);
+        assert!(
+            set_cookies[0]
+                .to_str()
+                .unwrap()
+                .starts_with(&format!("{SESSION_COOKIE}=;")),
+            "{:?}",
+            set_cookies[0]
+        );
+    }
+
+    #[sqlx::test]
+    async fn an_unauthenticated_request_gets_no_cookie(pool: PgPool) {
+        let response = app(test_state(pool))
+            .oneshot(request("GET", "/whoami", "other=1"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(!response.headers().contains_key(header::SET_COOKIE));
+    }
+}

--- a/apps/cas/src/sessions/mod.rs
+++ b/apps/cas/src/sessions/mod.rs
@@ -40,8 +40,9 @@ pub const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(7 * 24 * 60 * 60)
 
 /// How often an authenticated request may reset the idle clock. A request
 /// inside this window after the last reset costs no write; one outside it
-/// renews the session and re-sends the cookie. A session's real idle limit is
-/// therefore between the timeout and the timeout plus this window, which is
+/// renews the session and re-sends the cookie. The clock therefore lags the
+/// last request by up to one window: measured from that request, a session
+/// ends between the timeout minus this window and the timeout, which is
 /// nothing against seven days, and the price of a session is one write per
 /// hour of use, not one per request.
 pub const SESSION_RENEWAL_WINDOW: Duration = Duration::from_secs(60 * 60);

--- a/apps/cas/src/sessions/mod.rs
+++ b/apps/cas/src/sessions/mod.rs
@@ -3,9 +3,10 @@
 //! A session is a row in `sessions` and a random token in an HttpOnly cookie.
 //! The row stores the SHA-256 of the token, never the token itself, so a read
 //! of the table does not hand out live sessions. Registration and login create
-//! a session; `GET /api/me` reads it; `POST /api/logout` deletes it. Expiry is
-//! absolute and enforced by the database clock. See
-//! `docs/adr/0004-cookie-sessions.md`.
+//! a session; `GET /api/me` reads it; `POST /api/logout` deletes it. A session
+//! ends when it has been idle for [`SESSION_IDLE_TIMEOUT`] or, whatever
+//! happens, [`SESSION_LIFETIME`] after it was created; both clocks are the
+//! database's. See `docs/adr/0004-cookie-sessions.md`.
 //!
 //! This module is the vocabulary: the token, its hash, the row. Issuing,
 //! resolving and revoking sessions is [`service`]; the SQL is `repository`;
@@ -26,10 +27,30 @@ use crate::accounts::Account;
 
 pub use service::SessionService;
 
-/// How long a session lives from the moment it is created. Absolute, not
-/// sliding: the cookie's `Max-Age` and the row's `expires_at` are both derived
-/// from this one number, so the browser and the server give up together.
+/// The absolute cap: how long a session may live from the moment it is
+/// created, however active it is. The row's `expires_at` is derived from it
+/// and never moves.
 pub const SESSION_LIFETIME: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// The idle timeout: a session that has not been used for this long is over,
+/// even if the absolute cap is far away. The cookie's `Max-Age` is derived
+/// from it, so the browser drops the cookie when the server would stop
+/// honouring it.
+pub const SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// How often an authenticated request may reset the idle clock. A request
+/// inside this window after the last reset costs no write; one outside it
+/// renews the session and re-sends the cookie. A session's real idle limit is
+/// therefore between the timeout and the timeout plus this window, which is
+/// nothing against seven days, and the price of a session is one write per
+/// hour of use, not one per request.
+pub const SESSION_RENEWAL_WINDOW: Duration = Duration::from_secs(60 * 60);
+
+/// `std::time::Duration` for arithmetic with `OffsetDateTime`. The constants
+/// above are small enough that the conversion cannot fail.
+pub(crate) fn as_time(duration: Duration) -> time::Duration {
+    time::Duration::try_from(duration).expect("a session duration fits in time::Duration")
+}
 
 /// Bytes of entropy in a token. 256 bits: not guessable, and the same size as
 /// the hash that indexes it.
@@ -94,7 +115,30 @@ pub struct Session {
     pub id: Uuid,
     pub account_id: Uuid,
     pub created_at: OffsetDateTime,
+    /// The absolute cap, fixed at creation.
     pub expires_at: OffsetDateTime,
+    /// The last time the idle clock was reset: creation, then each renewal.
+    pub last_seen_at: OffsetDateTime,
+}
+
+impl Session {
+    /// When the session stops being honoured if nothing renews it: the idle
+    /// timeout from the last reset, or the absolute cap, whichever is first.
+    /// What `/api/me` reports and what the cookie's `Max-Age` is cut to.
+    pub fn valid_until(&self) -> OffsetDateTime {
+        (self.last_seen_at + as_time(SESSION_IDLE_TIMEOUT)).min(self.expires_at)
+    }
+}
+
+/// What [`SessionService::authenticate`] did to a session's idle clock, so
+/// the transport knows whether the browser needs a fresh cookie.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Renewal {
+    /// The last reset was inside the renewal window; nothing was written.
+    Kept,
+    /// The idle clock was reset; the cookie must be re-sent with a new
+    /// `Max-Age`.
+    Renewed,
 }
 
 /// Who a request is: the live session it presented and the account it
@@ -150,6 +194,30 @@ mod tests {
                 "{value:?} must not parse"
             );
         }
+    }
+
+    #[test]
+    fn a_session_is_valid_until_the_idle_timeout_or_the_cap() {
+        let now = OffsetDateTime::now_utc();
+        let mut session = Session {
+            id: Uuid::new_v4(),
+            account_id: Uuid::new_v4(),
+            created_at: now,
+            expires_at: now + as_time(SESSION_LIFETIME),
+            last_seen_at: now,
+        };
+
+        assert_eq!(session.valid_until(), now + as_time(SESSION_IDLE_TIMEOUT));
+
+        // Renewed one day before the cap: the cap wins.
+        session.last_seen_at = session.expires_at - time::Duration::days(1);
+        assert_eq!(session.valid_until(), session.expires_at);
+    }
+
+    #[test]
+    fn the_renewal_window_is_small_against_the_idle_timeout() {
+        assert!(SESSION_RENEWAL_WINDOW * 24 < SESSION_IDLE_TIMEOUT);
+        assert!(SESSION_IDLE_TIMEOUT < SESSION_LIFETIME);
     }
 
     #[test]

--- a/apps/cas/src/sessions/repository.rs
+++ b/apps/cas/src/sessions/repository.rs
@@ -2,12 +2,22 @@
 //! functions take an executor so the service can compose a transaction out of
 //! them and out of the accounts context's own functions.
 
+use time::OffsetDateTime;
 use uuid::Uuid;
 
-use super::{SESSION_LIFETIME, Session, TokenHash};
+use super::{SESSION_IDLE_TIMEOUT, SESSION_LIFETIME, SESSION_RENEWAL_WINDOW, Session, TokenHash};
+
+/// A live session as `find_live` returns it, with the one thing the service
+/// cannot see from the row alone: whether the idle clock is due for a reset,
+/// judged by the database clock like everything else about expiry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Live {
+    pub session: Session,
+    pub renewal_due: bool,
+}
 
 /// Inserts a session for an account. `expires_at` is measured by the
-/// database clock so every replica agrees on it.
+/// database clock so every replica agrees on it; the idle clock starts now.
 pub(super) async fn insert<'e, E>(
     executor: E,
     account_id: Uuid,
@@ -22,7 +32,7 @@ where
         Session,
         r#"INSERT INTO sessions (account_id, token_hash, expires_at)
            VALUES ($1, $2, now() + make_interval(secs => $3))
-           RETURNING id, account_id, created_at, expires_at"#,
+           RETURNING id, account_id, created_at, expires_at, last_seen_at"#,
         account_id,
         token_hash.as_ref(),
         ttl_secs,
@@ -31,24 +41,58 @@ where
     .await
 }
 
-/// The session a token names, if it exists and has not expired. An expired
-/// row is the same as no row: it is not returned, and it is not removed here
-/// either, so that housekeeping stays out of the request path.
+/// The session a token names, if it exists and neither clock has run out: it
+/// is before the absolute cap and was seen within the idle timeout. A row past
+/// either is the same as no row: it is not returned, and it is not removed
+/// here either, so that housekeeping stays out of the request path.
 pub(super) async fn find_live<'e, E>(
     executor: E,
     token_hash: &TokenHash,
-) -> Result<Option<Session>, sqlx::Error>
+) -> Result<Option<Live>, sqlx::Error>
 where
     E: sqlx::PgExecutor<'e>,
 {
-    sqlx::query_as!(
-        Session,
-        r#"SELECT id, account_id, created_at, expires_at
+    let idle_secs = SESSION_IDLE_TIMEOUT.as_secs_f64();
+    let window_secs = SESSION_RENEWAL_WINDOW.as_secs_f64();
+
+    let row = sqlx::query!(
+        r#"SELECT id, account_id, created_at, expires_at, last_seen_at,
+                  last_seen_at <= now() - make_interval(secs => $3) AS "renewal_due!"
            FROM sessions
-           WHERE token_hash = $1 AND expires_at > now()"#,
+           WHERE token_hash = $1
+             AND expires_at > now()
+             AND last_seen_at > now() - make_interval(secs => $2)"#,
         token_hash.as_ref(),
+        idle_secs,
+        window_secs,
     )
     .fetch_optional(executor)
+    .await?;
+
+    Ok(row.map(|row| Live {
+        session: Session {
+            id: row.id,
+            account_id: row.account_id,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+            last_seen_at: row.last_seen_at,
+        },
+        renewal_due: row.renewal_due,
+    }))
+}
+
+/// Resets a session's idle clock and returns the new `last_seen_at`. The
+/// absolute cap is untouched: renewal never moves `expires_at`. The service
+/// decides when to call this, from what `find_live` reported.
+pub(super) async fn renew<'e, E>(executor: E, id: Uuid) -> Result<OffsetDateTime, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_scalar!(
+        "UPDATE sessions SET last_seen_at = now() WHERE id = $1 RETURNING last_seen_at",
+        id,
+    )
+    .fetch_one(executor)
     .await
 }
 
@@ -94,6 +138,17 @@ mod tests {
             .unwrap();
     }
 
+    /// Moves a session's last use into the past by the given interval.
+    /// Unchecked query: see docs/TESTS.md.
+    async fn last_seen(pool: &PgPool, id: Uuid, ago: &str) {
+        sqlx::query("UPDATE sessions SET last_seen_at = now() - $2::interval WHERE id = $1")
+            .bind(id)
+            .bind(ago)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
     async fn count(pool: &PgPool) -> i64 {
         // Unchecked query: see docs/TESTS.md.
         sqlx::query_scalar("SELECT count(*) FROM sessions")
@@ -110,9 +165,19 @@ mod tests {
         let inserted = insert(&pool, account_id, &hash).await.unwrap();
         let found = find_live(&pool, &hash).await.unwrap();
 
-        assert_eq!(found, Some(inserted.clone()));
+        assert_eq!(
+            found,
+            Some(Live {
+                session: inserted.clone(),
+                renewal_due: false,
+            })
+        );
         assert_eq!(inserted.account_id, account_id);
         assert!(inserted.expires_at > inserted.created_at);
+        assert_eq!(
+            inserted.last_seen_at, inserted.created_at,
+            "the idle clock starts at creation"
+        );
     }
 
     #[sqlx::test]
@@ -135,6 +200,55 @@ mod tests {
 
         assert_eq!(found, None);
         assert_eq!(count(&pool).await, 1, "cleanup is not this query's job");
+    }
+
+    /// The idle clock is the second way out: a row well before its cap is
+    /// still not live once it has been unused for the idle timeout.
+    #[sqlx::test]
+    async fn an_idle_session_is_not_found_and_not_removed(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        let session = insert(&pool, account_id, &hash).await.unwrap();
+        last_seen(&pool, session.id, "7 days 1 second").await;
+
+        let found = find_live(&pool, &hash).await.unwrap();
+
+        assert_eq!(found, None);
+        assert_eq!(count(&pool).await, 1, "cleanup is not this query's job");
+    }
+
+    /// Renewal is due once the last reset is a whole window in the past, and
+    /// not a moment before: a fresh session and one seen half a window ago
+    /// are both reported as not due.
+    #[sqlx::test]
+    async fn renewal_is_due_only_outside_the_window(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        let session = insert(&pool, account_id, &hash).await.unwrap();
+
+        last_seen(&pool, session.id, "30 minutes").await;
+        assert!(!find_live(&pool, &hash).await.unwrap().unwrap().renewal_due);
+
+        last_seen(&pool, session.id, "61 minutes").await;
+        assert!(find_live(&pool, &hash).await.unwrap().unwrap().renewal_due);
+    }
+
+    /// Renewal moves the idle clock and nothing else: the cap stays where
+    /// creation put it.
+    #[sqlx::test]
+    async fn renew_resets_the_idle_clock_and_keeps_the_cap(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        let session = insert(&pool, account_id, &hash).await.unwrap();
+        last_seen(&pool, session.id, "2 hours").await;
+
+        let seen = renew(&pool, session.id).await.unwrap();
+
+        let live = find_live(&pool, &hash).await.unwrap().unwrap();
+        assert_eq!(live.session.last_seen_at, seen);
+        assert!(seen > session.last_seen_at);
+        assert_eq!(live.session.expires_at, session.expires_at);
+        assert!(!live.renewal_due);
     }
 
     /// The row must give up when the cookie does: both are derived from

--- a/apps/cas/src/sessions/repository.rs
+++ b/apps/cas/src/sessions/repository.rs
@@ -81,18 +81,30 @@ where
     }))
 }
 
-/// Resets a session's idle clock and returns the new `last_seen_at`. The
-/// absolute cap is untouched: renewal never moves `expires_at`. The service
-/// decides when to call this, from what `find_live` reported.
-pub(super) async fn renew<'e, E>(executor: E, id: Uuid) -> Result<OffsetDateTime, sqlx::Error>
+/// Resets a session's idle clock if it is still due, and returns the new
+/// `last_seen_at`. The window is checked again here, in the same statement
+/// as the write: two requests that both saw the clock due from `find_live`
+/// take the row lock in turn, and the second re-evaluates the condition on
+/// the row the first just wrote and matches nothing. `Ok(None)` is that, or
+/// a session deleted in the meantime; the service tells them apart. The
+/// absolute cap is untouched: renewal never moves `expires_at`.
+pub(super) async fn renew<'e, E>(
+    executor: E,
+    id: Uuid,
+) -> Result<Option<OffsetDateTime>, sqlx::Error>
 where
     E: sqlx::PgExecutor<'e>,
 {
+    let window_secs = SESSION_RENEWAL_WINDOW.as_secs_f64();
+
     sqlx::query_scalar!(
-        "UPDATE sessions SET last_seen_at = now() WHERE id = $1 RETURNING last_seen_at",
+        r#"UPDATE sessions SET last_seen_at = now()
+           WHERE id = $1 AND last_seen_at <= now() - make_interval(secs => $2)
+           RETURNING last_seen_at"#,
         id,
+        window_secs,
     )
-    .fetch_one(executor)
+    .fetch_optional(executor)
     .await
 }
 
@@ -242,13 +254,28 @@ mod tests {
         let session = insert(&pool, account_id, &hash).await.unwrap();
         last_seen(&pool, session.id, "2 hours").await;
 
-        let seen = renew(&pool, session.id).await.unwrap();
+        let seen = renew(&pool, session.id).await.unwrap().expect("due");
 
         let live = find_live(&pool, &hash).await.unwrap().unwrap();
         assert_eq!(live.session.last_seen_at, seen);
         assert!(seen > session.last_seen_at);
         assert_eq!(live.session.expires_at, session.expires_at);
         assert!(!live.renewal_due);
+    }
+
+    /// The write carries its own check: a session inside the window, or one
+    /// that is gone, is left alone and reported as such.
+    #[sqlx::test]
+    async fn renew_writes_nothing_inside_the_window_or_for_a_missing_session(pool: PgPool) {
+        let account_id = account(&pool).await;
+        let hash = SessionToken::generate().unwrap().hash();
+        let session = insert(&pool, account_id, &hash).await.unwrap();
+
+        assert_eq!(renew(&pool, session.id).await.unwrap(), None);
+        let live = find_live(&pool, &hash).await.unwrap().unwrap();
+        assert_eq!(live.session.last_seen_at, session.last_seen_at);
+
+        assert_eq!(renew(&pool, Uuid::new_v4()).await.unwrap(), None);
     }
 
     /// The row must give up when the cookie does: both are derived from

--- a/apps/cas/src/sessions/service.rs
+++ b/apps/cas/src/sessions/service.rs
@@ -2,14 +2,15 @@
 //!
 //! `create` is what registration and login call once an account is proven;
 //! `authenticate` is what the cookie extractor calls on every authenticated
-//! request; `revoke` is logout. The secret token exists in memory only
-//! between `create` and the response that sets the cookie.
+//! request, and it is also where a session's idle clock is reset; `revoke` is
+//! logout. The secret token exists in memory only between `create` and the
+//! response that sets the cookie.
 
 use sqlx::PgPool;
 use thiserror::Error;
 use uuid::Uuid;
 
-use super::{Authenticated, Session, SessionToken, repository};
+use super::{Authenticated, Renewal, Session, SessionToken, repository};
 use crate::accounts;
 
 #[derive(Debug, Error)]
@@ -58,14 +59,34 @@ impl SessionService {
     }
 
     /// Resolves a token to the session and account it names. `Ok(None)` for a
-    /// token that is unknown, expired or revoked, or whose account is gone.
+    /// token that is unknown, idle for too long, past its cap or revoked, or
+    /// whose account is gone.
+    ///
+    /// A live session whose last reset is a renewal window or more in the past
+    /// is renewed here: its idle clock and the account's `last_seen_at` move
+    /// together, in one transaction, as at creation. Inside the window nothing
+    /// is written, so a busy session costs one write per window, not one per
+    /// request. The caller learns which it was and re-sends the cookie on
+    /// [`Renewal::Renewed`].
     pub async fn authenticate(
         &self,
         token: &SessionToken,
-    ) -> Result<Option<Authenticated>, sqlx::Error> {
-        let Some(session) = repository::find_live(&self.pool, &token.hash()).await? else {
+    ) -> Result<Option<(Authenticated, Renewal)>, sqlx::Error> {
+        let Some(live) = repository::find_live(&self.pool, &token.hash()).await? else {
             return Ok(None);
         };
+        let mut session = live.session;
+
+        let renewal = if live.renewal_due {
+            let mut tx = self.pool.begin().await?;
+            session.last_seen_at = repository::renew(&mut *tx, session.id).await?;
+            accounts::touch_last_seen(&mut *tx, session.account_id).await?;
+            tx.commit().await?;
+            Renewal::Renewed
+        } else {
+            Renewal::Kept
+        };
+
         // The cascade removes sessions with their account, so a missing
         // account here is a race with that delete, and the answer is the same
         // as if the session had already gone.
@@ -73,7 +94,7 @@ impl SessionService {
             return Ok(None);
         };
 
-        Ok(Some(Authenticated { session, account }))
+        Ok(Some((Authenticated { session, account }, renewal)))
     }
 
     /// Ends the session a token names. `Ok(false)` when there was none:
@@ -102,7 +123,7 @@ mod tests {
         let service = SessionService::new(pool);
 
         let issued = service.create(account.id).await.unwrap();
-        let authenticated = service
+        let (authenticated, renewal) = service
             .authenticate(&issued.token)
             .await
             .unwrap()
@@ -111,6 +132,77 @@ mod tests {
         assert_eq!(authenticated.session, issued.session);
         assert_eq!(authenticated.account.id, account.id);
         assert_eq!(authenticated.account.display_name, account.display_name);
+        assert_eq!(renewal, Renewal::Kept, "just created: inside the window");
+    }
+
+    /// Moves a session's last use into the past by the given interval.
+    /// Unchecked query: see docs/TESTS.md.
+    async fn last_seen(pool: &PgPool, id: Uuid, ago: &str) {
+        sqlx::query("UPDATE sessions SET last_seen_at = now() - $2::interval WHERE id = $1")
+            .bind(id)
+            .bind(ago)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    /// Two requests inside the renewal window leave the row exactly as it
+    /// was: the idle clock is not a per-request write.
+    #[sqlx::test]
+    async fn requests_inside_the_window_do_not_write(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool);
+        let issued = service.create(account.id).await.unwrap();
+
+        for _ in 0..2 {
+            let (authenticated, renewal) =
+                service.authenticate(&issued.token).await.unwrap().unwrap();
+
+            assert_eq!(renewal, Renewal::Kept);
+            assert_eq!(
+                authenticated.session.last_seen_at,
+                issued.session.last_seen_at
+            );
+        }
+    }
+
+    /// A request outside the window resets the idle clock, leaves the cap,
+    /// and marks the account as seen; the next request is inside the new
+    /// window again.
+    #[sqlx::test]
+    async fn a_request_outside_the_window_renews_the_session(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        let issued = service.create(account.id).await.unwrap();
+        last_seen(&pool, issued.session.id, "2 hours").await;
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("UPDATE accounts SET last_seen_at = now() - interval '2 hours' WHERE id = $1")
+            .bind(account.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let (renewed, renewal) = service.authenticate(&issued.token).await.unwrap().unwrap();
+
+        assert_eq!(renewal, Renewal::Renewed);
+        assert!(renewed.session.last_seen_at >= issued.session.last_seen_at);
+        assert_eq!(renewed.session.expires_at, issued.session.expires_at);
+        assert!(renewed.account.last_seen_at >= renewed.session.last_seen_at);
+
+        let (again, renewal) = service.authenticate(&issued.token).await.unwrap().unwrap();
+        assert_eq!(renewal, Renewal::Kept);
+        assert_eq!(again.session, renewed.session);
+    }
+
+    /// Idle for longer than the timeout: over, however far the cap is.
+    #[sqlx::test]
+    async fn an_idle_session_does_not_authenticate(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        let issued = service.create(account.id).await.unwrap();
+        last_seen(&pool, issued.session.id, "8 days").await;
+
+        assert_eq!(service.authenticate(&issued.token).await.unwrap(), None);
     }
 
     #[sqlx::test]

--- a/apps/cas/src/sessions/service.rs
+++ b/apps/cas/src/sessions/service.rs
@@ -68,24 +68,44 @@ impl SessionService {
     /// is written, so a busy session costs one write per window, not one per
     /// request. The caller learns which it was and re-sends the cookie on
     /// [`Renewal::Renewed`].
+    ///
+    /// The read that says renewal is due and the write that does it are not
+    /// one step, so the write checks the window again and may find nothing to
+    /// do: another request renewed the session a moment ago, or logout
+    /// removed it. Either way this request is treated as one that arrived a
+    /// moment later: it reads the session again and authenticates with what
+    /// it finds, or is unauthenticated if nothing is there.
     pub async fn authenticate(
         &self,
         token: &SessionToken,
     ) -> Result<Option<(Authenticated, Renewal)>, sqlx::Error> {
-        let Some(live) = repository::find_live(&self.pool, &token.hash()).await? else {
+        let hash = token.hash();
+        let Some(live) = repository::find_live(&self.pool, &hash).await? else {
             return Ok(None);
         };
         let mut session = live.session;
 
-        let renewal = if live.renewal_due {
+        let mut renewal = Renewal::Kept;
+        if live.renewal_due {
             let mut tx = self.pool.begin().await?;
-            session.last_seen_at = repository::renew(&mut *tx, session.id).await?;
-            accounts::touch_last_seen(&mut *tx, session.account_id).await?;
-            tx.commit().await?;
-            Renewal::Renewed
-        } else {
-            Renewal::Kept
-        };
+            match repository::renew(&mut *tx, session.id).await? {
+                Some(last_seen_at) => {
+                    accounts::touch_last_seen(&mut *tx, session.account_id).await?;
+                    tx.commit().await?;
+                    session.last_seen_at = last_seen_at;
+                    renewal = Renewal::Renewed;
+                }
+                None => {
+                    // Nothing was written; dropping the transaction rolls it
+                    // back. The session as read is stale by one race.
+                    drop(tx);
+                    let Some(again) = repository::find_live(&self.pool, &hash).await? else {
+                        return Ok(None);
+                    };
+                    session = again.session;
+                }
+            }
+        }
 
         // The cascade removes sessions with their account, so a missing
         // account here is a race with that delete, and the answer is the same
@@ -192,6 +212,77 @@ mod tests {
         let (again, renewal) = service.authenticate(&issued.token).await.unwrap().unwrap();
         assert_eq!(renewal, Renewal::Kept);
         assert_eq!(again.session, renewed.session);
+    }
+
+    /// Two requests arrive at once with the clock due. Each is held at its
+    /// renewal write by a row lock taken here, so that both have read the
+    /// session as due before either writes; on release, exactly one renews,
+    /// the other finds the window already reset and keeps the fresh state.
+    #[sqlx::test]
+    async fn concurrent_requests_renew_once(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        let issued = service.create(account.id).await.unwrap();
+        last_seen(&pool, issued.session.id, "2 hours").await;
+
+        let mut lock = pool.begin().await.unwrap();
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("SELECT id FROM sessions WHERE id = $1 FOR UPDATE")
+            .bind(issued.session.id)
+            .execute(&mut *lock)
+            .await
+            .unwrap();
+        let requests: Vec<_> = (0..2)
+            .map(|_| {
+                let service = service.clone();
+                let token = issued.token.clone();
+                tokio::spawn(async move { service.authenticate(&token).await })
+            })
+            .collect();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        lock.commit().await.unwrap();
+
+        let mut renewed = 0;
+        let mut seen = Vec::new();
+        for request in requests {
+            let (authenticated, renewal) = request.await.unwrap().unwrap().unwrap();
+            if renewal == Renewal::Renewed {
+                renewed += 1;
+            }
+            seen.push(authenticated.session.last_seen_at);
+        }
+
+        assert_eq!(renewed, 1, "one write for the two of them");
+        assert_eq!(seen[0], seen[1], "the loser reads what the winner wrote");
+        assert!(seen[0] > issued.session.last_seen_at);
+    }
+
+    /// Logout lands between the read that found the session due and the
+    /// renewal write: the request is unauthenticated, not an error. The
+    /// uncommitted delete holds the row lock the renewal must wait for.
+    #[sqlx::test]
+    async fn a_session_deleted_during_renewal_does_not_authenticate(pool: PgPool) {
+        let account = account(&pool).await;
+        let service = SessionService::new(pool.clone());
+        let issued = service.create(account.id).await.unwrap();
+        last_seen(&pool, issued.session.id, "2 hours").await;
+
+        let mut logout = pool.begin().await.unwrap();
+        // Unchecked query: see docs/TESTS.md.
+        sqlx::query("DELETE FROM sessions WHERE id = $1")
+            .bind(issued.session.id)
+            .execute(&mut *logout)
+            .await
+            .unwrap();
+        let request = {
+            let service = service.clone();
+            let token = issued.token.clone();
+            tokio::spawn(async move { service.authenticate(&token).await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        logout.commit().await.unwrap();
+
+        assert_eq!(request.await.unwrap().unwrap(), None);
     }
 
     /// Idle for longer than the timeout: over, however far the cap is.

--- a/apps/cas/src/webauthn/http/login.rs
+++ b/apps/cas/src/webauthn/http/login.rs
@@ -87,7 +87,7 @@ pub(super) async fn verify_login(
     let issued = state.sessions.create(logged_in.account.id).await?;
 
     Ok((
-        jar.add(state.cookies.session(&issued.token)),
+        jar.add(state.cookies.session(&issued.token, &issued.session)),
         Json(VerifyLoginResponse {
             account_id: logged_in.account.id,
             credential_id: logged_in.credential.passkey.cred_id().clone(),
@@ -222,7 +222,7 @@ mod tests {
         assert!(credentials[0].last_used_at.is_some());
 
         // The cookie names a live session of the signed-in account.
-        let authenticated = SessionService::new(pool)
+        let (authenticated, _) = SessionService::new(pool)
             .authenticate(&token)
             .await
             .unwrap()

--- a/apps/cas/src/webauthn/http/registration.rs
+++ b/apps/cas/src/webauthn/http/registration.rs
@@ -116,7 +116,7 @@ pub(super) async fn verify_registration(
     let issued = state.sessions.create(registered.account.id).await?;
 
     Ok((
-        jar.add(state.cookies.session(&issued.token)),
+        jar.add(state.cookies.session(&issued.token, &issued.session)),
         Json(VerifyRegistrationResponse {
             account_id: registered.account.id,
             credential_id: registered.credential.passkey.cred_id().clone(),
@@ -257,7 +257,7 @@ mod tests {
         assert_eq!(credentials[0].name, DEFAULT_PASSKEY_NAME);
 
         // The cookie names a live session of the new account.
-        let authenticated = SessionService::new(pool)
+        let (authenticated, _) = SessionService::new(pool)
             .authenticate(&token)
             .await
             .unwrap()


### PR DESCRIPTION
Closes #697.

## Decision (ADR 0004, amended in (c))

Sessions get two clocks, both the database's:

- **Idle timeout, 7 days**, reset by an authenticated request at most once per **renewal window of 1 hour**. A request inside the window writes nothing; one outside it resets `last_seen_at` on the session and on the account in one transaction.
- **Absolute cap, 30 days**, unchanged: `expires_at` is fixed at creation and never moves.

Why seven days: it is what a player who opens the game most weeks never notices, and a passkey makes signing in again a single touch, which is what makes a shorter idle limit affordable. The cap bounds how long a stolen cookie is worth anything. The cookie stays persistent (`Max-Age`): players close the tab between rounds.

## Changes

- Migration: `sessions.last_seen_at` (default `now()`, nobody is signed out) and an index for the future cleanup job.
- `find_live` checks both clocks and reports whether renewal is due, all by the database clock; `renew` resets the idle clock only.
- `SessionService::authenticate` returns `(Authenticated, Renewal)`; renewal is one transaction with the account's `last_seen_at`.
- Cookie `Max-Age` runs to `Session::valid_until()` (idle timeout from the last reset, or the cap, whichever is first). A renewal re-sends the cookie: the `Authenticated` extractor cannot touch the response, so a layer on `/api` (`sessions::http::renewal`) carries it out through a per-request slot. A handler that sets the cookie itself wins.
- `GET /api/me` reports `sessionExpiresAt` as that effective moment rather than the absolute cap.
- `.sqlx` refreshed.

## Tests

Repository: idle expiry is not found and not removed, renewal due only outside the window, renew keeps the cap. Service: no write inside the window, renewal outside it moves session and account, idle session does not authenticate. Transport: renewal re-sends the cookie with `Max-Age` at the idle timeout, no cookie inside the window, handler's own cookie wins, no cookie on 401.

`cargo test`: 160 passed. `cargo clippy --all-targets -- -D warnings`: clean.

## Note

#698 (in flight) also touches `api_router` and ADR 0004; whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)