### PR TITLE
feat(cas): passkey management API (#668)

### DIFF
--- a/apps/cas/.sqlx/query-3d50b44c7b8c2b8f0478d95c6ceb23fd9d0d2b90ac3132e95b78bd4819596a8c.json
+++ b/apps/cas/.sqlx/query-3d50b44c7b8c2b8f0478d95c6ceb23fd9d0d2b90ac3132e95b78bd4819596a8c.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM passkey_credentials WHERE id = $1 AND account_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3d50b44c7b8c2b8f0478d95c6ceb23fd9d0d2b90ac3132e95b78bd4819596a8c"
+}

--- a/apps/cas/.sqlx/query-707f9c41a9d7b635a7eee782a3e29422d4dbc20b44bd99855179ae49580cedc1.json
+++ b/apps/cas/.sqlx/query-707f9c41a9d7b635a7eee782a3e29422d4dbc20b44bd99855179ae49580cedc1.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE passkey_credentials\n           SET name = $3\n           WHERE id = $1 AND account_id = $2\n           RETURNING\n               id,\n               account_id,\n               credential_id,\n               credential AS \"credential: Json<Passkey>\",\n               name,\n               created_at,\n               last_used_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "account_id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "account_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "credential_id",
+        "type_info": "Bytea",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "credential_id"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "credential: Json<Passkey>",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "credential"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "last_used_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "last_used_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "707f9c41a9d7b635a7eee782a3e29422d4dbc20b44bd99855179ae49580cedc1"
+}

--- a/apps/cas/.sqlx/query-ce80318fd25deae5e27ed5bfec87ea477070efe858628e8ac01562bfabdac0c9.json
+++ b/apps/cas/.sqlx/query-ce80318fd25deae5e27ed5bfec87ea477070efe858628e8ac01562bfabdac0c9.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM passkey_credentials\n           WHERE account_id = $1\n           ORDER BY id\n           FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "passkey_credentials",
+            "name": "id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ce80318fd25deae5e27ed5bfec87ea477070efe858628e8ac01562bfabdac0c9"
+}

--- a/apps/cas/docs/LAYOUT.md
+++ b/apps/cas/docs/LAYOUT.md
@@ -16,6 +16,8 @@ apps/cas/
     config.rs          ┐
     db.rs              │ shared infrastructure: knows no context
     migrations.rs      ┘
+    shared/            shared vocabulary: rules and types more than one context
+      label.rs           needs and none owns (a user-facing label's rules)
     testing.rs         test helpers, cfg(test) only
     http/              transport root: mounts the contexts, owns the wire contract
       mod.rs           router, middleware stack, pool construction
@@ -62,9 +64,18 @@ Each rule says what a layer is for and what it must not touch.
    binaries, knows no context. `db` classifies database failures (unavailable,
    busy, or a bug the code has no name for); a transport only maps that verdict
    to a status.
-6. **Dependency direction** — `http → <context>/http → services → repository → db`. Domain types
+6. **Shared vocabulary** — `shared/`. Domain-level rules and types that at
+   least two contexts need and none of them owns: the rules for a user-facing
+   label are the first. The bar for entry is that second context; a rule one
+   context uses stays in that context. No axum, no SQL, no configuration.
+   A context's newtype over a shared rule (`DisplayName`, `PasskeyName`)
+   stays in the context, with an error type of its own, so the wire error
+   code stays next to the handler that maps it.
+7. **Dependency direction** — `http → <context>/http → services → repository → db`. Domain types
    are visible to every layer. Contexts talk to each other through their public
-   types and services, never through another context's repository.
-7. **Tests** live next to the code. Repositories and services are tested with
+   types and services, never through another context's repository, and never
+   reach into another context for a rule: what two contexts share lives in
+   `shared/`.
+8. **Tests** live next to the code. Repositories and services are tested with
    `#[sqlx::test]`, transport through the full router. Shared fixtures are in
    `testing.rs`. See TESTS.md.

--- a/apps/cas/docs/adr/0006-passkey-management.md
+++ b/apps/cas/docs/adr/0006-passkey-management.md
@@ -1,0 +1,81 @@
+# 6. Passkey management
+
+## Status
+
+Accepted (2026-09-12), with [#668](https://github.com/MemeBattle/monorepo/issues/668).
+
+## Context
+
+Registration (ADR 0001) stores a passkey under a default name and login
+(ADR 0003) uses whichever passkey the authenticator offers. An account that
+has more than one needs to tell them apart, and one that has lost a device
+needs to remove its key. There is no recovery in v1 (`docs/PLAN.md`): an
+account whose last passkey is gone can never be signed into again, and the
+plan's answer is a second passkey rather than a reset flow.
+
+The session (ADR 0004) says who is asking. The question is what an account
+may do to its own passkeys, what it learns about anyone else's, and how the
+last-passkey rule holds when two requests race.
+
+## Decision
+
+**(a) `/api/passkeys` is a resource of the signed-in account, not a
+ceremony.** `GET /api/passkeys` lists, `PATCH /api/passkeys/{id}` renames,
+`DELETE /api/passkeys/{id}` deletes. It is mounted next to `/api/webauthn`
+rather than under it: the ceremonies are how a passkey comes to exist, this
+is what happens to it afterwards, and the frontend addresses the two as
+different things. Every handler takes `Authenticated`; the account id comes
+from the session and never from the request.
+
+**(b) A passkey that is not yours does not exist.** Rename and delete look
+the row up by its id *and* the account id in one query, and a miss is
+`404 passkey_not_found` whether the id belongs to someone else or to no one.
+A caller learns nothing about which ids exist beyond its own. The list shows
+the id, the name, `created_at` and `last_used_at`; the credential itself,
+public key and counter included, is server-side state and is never sent.
+
+**(c) The last passkey stays.** Deleting an account's only passkey is
+`409 last_passkey`, with a message that says what to do instead: add another
+one first. A conflict rather than a bad request, because the same request
+succeeds once the account's state changes. The rule is about the count, not
+the account type: a guest has no passkeys to delete, so "the last passkey of
+a full account" and "the last passkey" are the same rule.
+
+**(d) The count is taken under a lock.** The delete runs in a transaction
+that first selects the account's passkey rows `FOR UPDATE`, then counts,
+then deletes. Two deletes of the two remaining passkeys at once would both
+count two and both proceed, leaving none; with the lock the second waits and
+counts what the first left. Contention is per account and the transaction is
+one read and one write.
+
+**(e) A passkey's name is a display name.** It is shown as-is in a list,
+next to other names, so it gets the same sanitising and the same rejections
+as an account's display name (`accounts::DisplayName`): spaces normalised,
+NFC, no invisible or direction-changing characters, the same length cap. The
+type is its own (`PasskeyName`) because the two are different things, but
+the rules are one implementation, not two. A bad name is
+`400 invalid_passkey_name`.
+
+**(f) Deleting a passkey ends no session.** As ADR 0004 says, a passkey is a
+way in, not the session itself. The dashboard session that deletes a passkey
+carries on; a session opened on a lost device carries on too until it
+expires or is revoked. "Sign out everywhere" belongs with session listing,
+later.
+
+## Consequences
+
+- A `DELETE` with no body is exactly the request ADR 0005 put the Fetch
+  Metadata line in front of; it is covered by where it is mounted.
+- The API can remove a passkey but not add one to an existing account:
+  registration creates an account, and there is no ceremony yet for a
+  signed-in account to register another authenticator. The last-passkey
+  rule therefore holds every account at its one registration passkey until
+  that ceremony exists; it is the next ticket in this area, and the
+  dashboard (#671) needs it for the "add a second passkey" nudge.
+- The `insert_passkey` write that registration uses is what that ceremony
+  will call; it is already visible to the crate, and the tests build accounts
+  with two passkeys through it.
+- A path segment that is not a uuid answers `400 invalid_path` in the
+  `ApiError` shape, through a `Path` extractor wrapper next to the `Json` one.
+- Rename is logged at `debug`, delete at `info`, with the passkey and account
+  ids: removing a way into an account is worth a line.

--- a/apps/cas/docs/adr/0006-passkey-management.md
+++ b/apps/cas/docs/adr/0006-passkey-management.md
@@ -48,13 +48,14 @@ count two and both proceed, leaving none; with the lock the second waits and
 counts what the first left. Contention is per account and the transaction is
 one read and one write.
 
-**(e) A passkey's name is a display name.** It is shown as-is in a list,
-next to other names, so it gets the same sanitising and the same rejections
-as an account's display name (`accounts::DisplayName`): spaces normalised,
-NFC, no invisible or direction-changing characters, the same length cap. The
-type is its own (`PasskeyName`) because the two are different things, but
-the rules are one implementation, not two. A bad name is
-`400 invalid_passkey_name`.
+**(e) A passkey's name is a label, like a display name.** It is shown
+as-is in a list, next to other names, so it gets the same sanitising and the
+same rejections as an account's display name: spaces normalised, NFC, no
+invisible or direction-changing characters, the same length cap. The rules
+are one implementation in `shared::label`, owned by neither context; each
+context has its own newtype over them (`PasskeyName`, `DisplayName`) with an
+error type of its own, so the wire error code stays next to the handler
+that maps it. A bad name is `400 invalid_passkey_name`.
 
 **(f) Deleting a passkey ends no session.** As ADR 0004 says, a passkey is a
 way in, not the session itself. The dashboard session that deletes a passkey

--- a/apps/cas/src/accounts/display_name.rs
+++ b/apps/cas/src/accounts/display_name.rs
@@ -1,386 +1,58 @@
-//! The display name newtype: how a user-facing name is sanitised and
-//! validated. How it crosses the database boundary is the repository's
+//! The display name newtype: an account's user-facing name under the shared
+//! label rules. How it crosses the database boundary is the repository's
 //! business (`repository.rs`).
 
-use icu_properties::{
-    CodePointSetData,
-    props::{DefaultIgnorableCodePoint, VariationSelector},
-};
 use nutype::nutype;
-use unicode_general_category::GeneralCategory;
-use unicode_normalization::UnicodeNormalization;
 
-/// Upper bound on a display name, in characters. Long enough for a real name,
-/// short enough to keep the sign-in UI and the authenticator prompt readable.
-pub const MAX_DISPLAY_NAME_LENGTH: usize = 64;
+use crate::shared::label::{LabelError, sanitize_label, validate_label};
 
-/// Why a string is not a [`DisplayName`].
+/// Why a string is not a [`DisplayName`]: the label rules, under a name of
+/// this context's own so the transport can give it its own error code.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum DisplayNameError {
-    #[error("must not be empty")]
-    Empty,
+#[error(transparent)]
+pub struct DisplayNameError(LabelError);
 
-    #[error("must be at most {MAX_DISPLAY_NAME_LENGTH} characters")]
-    TooLong,
-
-    /// A code point that must never reach a UI: controls, invisible format
-    /// characters (zero-width space, bidi overrides), line and paragraph
-    /// separators, surrogates, private use, unassigned. No position is
-    /// reported: it could only refer to the sanitised value, which the client
-    /// never sees, so it cannot map it back onto what the user typed.
-    #[error("must not contain control or invisible characters")]
-    DisallowedCharacter,
+fn validate_display_name(value: &str) -> Result<(), DisplayNameError> {
+    validate_label(value).map_err(DisplayNameError)
 }
 
-/// Unicode general category Zs: the space separators. Every one of them is
-/// mapped to ASCII space, following RFC 8266's width mapping, so that trimming
-/// and collapsing see a single kind of space.
-fn is_space_separator(c: char) -> bool {
-    const EN_QUAD_TO_HAIR_SPACE: std::ops::RangeInclusive<char> = '\u{2000}'..='\u{200a}';
-    matches!(
-        c,
-        '\u{20}' | '\u{a0}' | '\u{1680}' | '\u{202f}' | '\u{205f}' | '\u{3000}'
-    ) || EN_QUAD_TO_HAIR_SPACE.contains(&c)
-}
-
-/// Zero width joiner and non-joiner. They are the one part of category Cf a
-/// display name needs: emoji ZWJ sequences (👨‍👩‍👧) and Persian/Indic
-/// orthography are built from them.
-const ZERO_WIDTH_JOINERS: [char; 2] = ['\u{200d}', '\u{200c}'];
-
-fn is_zero_width_joiner(c: char) -> bool {
-    ZERO_WIDTH_JOINERS.contains(&c)
-}
-
-/// Normalises a display name: every Unicode space separator becomes an ASCII
-/// space, the result is put in NFC, then leading and trailing spaces are
-/// removed and runs of spaces collapse to one.
-///
-/// NFC, not NFKC: compatibility folding would rewrite what the user typed
-/// ("Ada™" → "AdaTM", "①" → "1", "x²" → "x2") for no safety gain, since the
-/// characters that actually mislead are rejected outright by
-/// [`validate_display_name`]. NFC still composes decomposed input, so
-/// "e\u{301}" and the Hangul jamo sequence "\u{1100}\u{1161}" become their
-/// precomposed forms.
-pub(crate) fn sanitize_display_name(value: String) -> String {
-    let mapped = value
-        .chars()
-        .map(|c| if is_space_separator(c) { ' ' } else { c })
-        .nfc();
-
-    let mut result = String::with_capacity(value.len());
-    let mut pending_space = false;
-    for c in mapped {
-        if c == ' ' {
-            // Held back so that a run of spaces, and a trailing one, never
-            // reach the output.
-            pending_space = !result.is_empty();
-            continue;
-        }
-        if pending_space {
-            result.push(' ');
-            pending_space = false;
-        }
-        result.push(c);
-    }
-    result
-}
-
-fn is_variation_selector(c: char) -> bool {
-    CodePointSetData::new::<VariationSelector>().contains(c)
-}
-
-fn is_combining_mark(c: char) -> bool {
-    matches!(
-        unicode_general_category::get_general_category(c),
-        GeneralCategory::NonspacingMark
-            | GeneralCategory::SpacingMark
-            | GeneralCategory::EnclosingMark
-    )
-}
-
-/// A base for combining marks and selectors, or the right side of a joiner.
-/// Unicode properties describe characters, not font-specific glyph coverage.
-fn is_visible_base(c: char) -> bool {
-    is_allowed_character(c)
-        && c != ' '
-        && !is_combining_mark(c)
-        && !CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(c)
-}
-
-/// General categories alone miss invisibles such as CGJ and Hangul fillers.
-/// Use Unicode's Default_Ignorable_Code_Point property as well, with contextual
-/// exceptions for joiners and variation selectors below.
-fn is_allowed_character(c: char) -> bool {
-    if is_zero_width_joiner(c) || is_variation_selector(c) {
-        return true;
-    }
-    // Braille Pattern Blank has no dots, but is a symbol rather than a space
-    // or default-ignorable character in Unicode.
-    c != '\u{2800}'
-        && !CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(c)
-        && !matches!(
-            unicode_general_category::get_general_category(c),
-            GeneralCategory::Control
-                | GeneralCategory::Format
-                | GeneralCategory::LineSeparator
-                | GeneralCategory::ParagraphSeparator
-                | GeneralCategory::Surrogate
-                | GeneralCategory::PrivateUse
-                | GeneralCategory::Unassigned
-        )
-}
-
-/// Rejects anything invisible or direction-changing, then the empty and the
-/// over-long. Runs on the sanitised value.
-///
-/// Marks need a preceding base, selectors must immediately follow a base, and
-/// joiners need a base on both sides. A mark or selector may precede a joiner
-/// (as in emoji and Indic text), but cannot supply the base itself.
-pub(crate) fn validate_display_name(value: &str) -> Result<(), DisplayNameError> {
-    if value.is_empty() {
-        return Err(DisplayNameError::Empty);
-    }
-    if value.chars().count() > MAX_DISPLAY_NAME_LENGTH {
-        return Err(DisplayNameError::TooLong);
-    }
-
-    let mut previous: Option<char> = None;
-    let mut has_base = false;
-    let mut characters = value.chars().peekable();
-    while let Some(c) = characters.next() {
-        if !is_allowed_character(c) {
-            return Err(DisplayNameError::DisallowedCharacter);
-        }
-        if c == ' ' {
-            has_base = false;
-        } else if is_variation_selector(c) {
-            if !previous.is_some_and(is_visible_base) {
-                return Err(DisplayNameError::DisallowedCharacter);
-            }
-        } else if is_zero_width_joiner(c) {
-            if !has_base || !characters.peek().copied().is_some_and(is_visible_base) {
-                return Err(DisplayNameError::DisallowedCharacter);
-            }
-            has_base = false;
-        } else if is_combining_mark(c) {
-            if !has_base {
-                return Err(DisplayNameError::DisallowedCharacter);
-            }
-        } else {
-            has_base = true;
-        }
-        previous = Some(c);
-    }
-
-    Ok(())
-}
-
-/// A user-facing name, valid by construction.
-///
-/// Sanitised (space mapping, NFC, trimming) and validated (no invisible or
-/// unassigned characters, length cap) in house, so every UI and every
-/// authenticator prompt can show it as-is: no control or invisible characters,
-/// no bidi tricks, no leading or doubled spaces. Deserialising re-validates, so
-/// a stored or received value is as safe as a freshly constructed one.
-///
-/// This deliberately does not use the PRECIS Nickname profile
-/// (`precis-profiles`). That crate's 0.1.13 space trimming indexes bytes with a
-/// char index, so it panics on "Ада " and swallows interior spaces in
-/// "José  Silva"; it deletes non-ASCII spaces instead of mapping them to
-/// U+0020; and it tests the string class before normalising, so decomposed
-/// Hangul is rejected. The profile itself also rejects U+FE0F and ZWJ
-/// sequences, which rules out most modern emoji — not an option for a game's
-/// display name.
+/// A user-facing name, valid by construction under the label rules
+/// (`crate::shared::label`): sanitised (space mapping, NFC, trimming) and
+/// validated (no invisible or unassigned characters, length cap), so every
+/// UI and every authenticator prompt can show it as-is. Deserialising
+/// re-validates, so a stored or received value is as safe as a freshly
+/// constructed one.
 #[nutype(
-    sanitize(with = sanitize_display_name),
+    sanitize(with = sanitize_label),
     validate(with = validate_display_name, error = DisplayNameError),
     derive(Debug, Clone, PartialEq, Eq, AsRef, Deref, Display, Into, Serialize, Deserialize),
 )]
 pub struct DisplayName(String);
 
 #[cfg(test)]
-mod display_name_tests {
+mod tests {
     use super::*;
+    use crate::shared::label::MAX_LABEL_LENGTH;
 
-    fn name(value: &str) -> Result<String, DisplayNameError> {
-        DisplayName::try_new(value).map(Into::into)
-    }
-
+    /// The label rules apply; the rules themselves are tested where they
+    /// live, in `shared::label`.
     #[test]
-    fn keeps_an_ordinary_name() {
-        for value in ["Ada Lovelace", "Ада", "Zoë", "O'Brien", "Jean-Luc", "李雷"] {
-            assert_eq!(name(value), Ok(value.to_owned()));
-        }
-    }
-
-    /// Emoji are made of exactly the characters a naive "no invisibles" rule
-    /// throws away: U+FE0F, skin tone modifiers, the keycap combining mark and
-    /// the zero width joiner.
-    #[test]
-    fn keeps_emoji() {
-        for value in [
-            "Ada 🚀",
-            "Ada \u{2764}\u{fe0f}",
-            "Ada 👨\u{200d}👩\u{200d}👧",
-            "👍🏽 Ada",
-            "1\u{fe0f}\u{20e3}",
-            "👩\u{200d}❤️\u{200d}👩",
-            "🏳\u{fe0f}\u{200d}🌈",
-        ] {
-            assert_eq!(name(value), Ok(value.to_owned()));
-        }
-    }
-
-    #[test]
-    fn trims_and_collapses_spaces() {
-        assert_eq!(name("  Ada   Lovelace  "), Ok("Ada Lovelace".to_owned()));
-        // Non-ASCII spaces become ASCII ones and collapse with them.
-        assert_eq!(name("Ada\u{a0}Lovelace"), Ok("Ada Lovelace".to_owned()));
+    fn a_display_name_is_a_sanitised_valid_label() {
         assert_eq!(
-            name("Ada\u{3000} \u{2003}Lovelace"),
+            DisplayName::try_new("  Ada\u{a0} Lovelace ").map(Into::<String>::into),
             Ok("Ada Lovelace".to_owned())
         );
-        assert_eq!(name("\u{a0}Ada\u{a0}"), Ok("Ada".to_owned()));
-        // Trimming works on characters, not bytes: a multi-byte name followed
-        // by a space is not truncated, and interior spaces survive.
-        assert_eq!(name("Ада "), Ok("Ада".to_owned()));
-        assert_eq!(name("Zoë "), Ok("Zoë".to_owned()));
-        assert_eq!(name("José  Silva"), Ok("José Silva".to_owned()));
-    }
-
-    /// NFC composes decomposed input but, unlike NFKC, leaves compatibility
-    /// characters alone: they are what the user typed and none of them can
-    /// impersonate another name.
-    #[test]
-    fn normalises_to_nfc() {
-        assert_eq!(name("e\u{301}"), Ok("\u{e9}".to_owned()));
-        // Conjoining Hangul jamo compose into the syllable 가.
-        assert_eq!(name("\u{1100}\u{1161}"), Ok("\u{ac00}".to_owned()));
-
-        for value in ["Ada™", "①", "ﬁsh", "x²"] {
-            assert_eq!(name(value), Ok(value.to_owned()));
-        }
-    }
-
-    #[test]
-    fn rejects_empty_names() {
-        assert_eq!(name(""), Err(DisplayNameError::Empty));
-        assert_eq!(name("   "), Err(DisplayNameError::Empty));
-        assert_eq!(name("\u{a0}"), Err(DisplayNameError::Empty));
-    }
-
-    #[test]
-    fn rejects_names_over_the_limit() {
-        assert!(name(&"a".repeat(MAX_DISPLAY_NAME_LENGTH)).is_ok());
         assert_eq!(
-            name(&"a".repeat(MAX_DISPLAY_NAME_LENGTH + 1)),
-            Err(DisplayNameError::TooLong)
+            DisplayName::try_new(""),
+            Err(DisplayNameError(LabelError::Empty))
         );
-    }
-
-    /// Invisible and direction-changing characters would let a name render as
-    /// empty or as another name in the authenticator prompt. Surrogates are
-    /// not covered: a Rust `str` cannot hold one.
-    #[test]
-    fn rejects_control_and_format_characters() {
-        for value in [
-            "Ada\u{7}",
-            "\u{200b}",
-            "Ada\u{200b}",
-            "\u{202e}adA",
-            "\u{feff}Ada",
-            "\u{2028}Ada",
-            "Ada\u{e000}",
-        ] {
-            assert_eq!(
-                name(value),
-                Err(DisplayNameError::DisallowedCharacter),
-                "{value:?} must be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_invisibles_outside_the_format_category() {
-        for invisible in [
-            '\u{034f}', '\u{115f}', '\u{1160}', '\u{17b4}', '\u{17b5}', '\u{2800}', '\u{3164}',
-            '\u{ffa0}',
-        ] {
-            for value in [
-                invisible.to_string(),
-                format!("Ada{invisible}"),
-                format!("A{invisible}B"),
-            ] {
-                assert_eq!(
-                    name(&value),
-                    Err(DisplayNameError::DisallowedCharacter),
-                    "{value:?} must be rejected"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn rejects_selectors_and_marks_without_a_base() {
-        for value in [
-            "\u{fe0f}",
-            "\u{e0100}",
-            "\u{180b}",
-            "\u{fe0f}Ada",
-            "Ada \u{fe0f}",
-            "A\u{fe0f}\u{fe0f}",
-            "\u{301}",
-            "Ada \u{301}",
-            "\u{fe0f}\u{200d}\u{fe0f}",
-            "A\u{200d}\u{fe0f}",
-            "A\u{200d}\u{301}B",
-        ] {
-            assert_eq!(
-                name(value),
-                Err(DisplayNameError::DisallowedCharacter),
-                "{value:?} must be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn keeps_marks_and_selectors_with_a_base() {
-        for value in [
-            "q\u{301}\u{302}",
-            "\u{4e00}\u{e0100}",
-            "\u{1820}\u{180b}",
-            "\u{915}\u{94d}\u{200d}\u{937}",
-        ] {
-            assert_eq!(name(value), Ok(value.to_owned()));
-        }
-    }
-
-    /// A zero width joiner is only allowed where it joins two visible
-    /// characters; anywhere else it is invisible padding.
-    #[test]
-    fn rejects_a_joiner_with_nothing_to_join() {
-        for value in [
-            "\u{200d}Ada",
-            "Ada\u{200d}",
-            "Ada\u{200d}\u{200d}Bob",
-            "Ada \u{200d}Bob",
-        ] {
-            assert_eq!(
-                name(value),
-                Err(DisplayNameError::DisallowedCharacter),
-                "{value:?} must be rejected"
-            );
-        }
-    }
-
-    #[test]
-    fn keeps_joiners_between_letters() {
-        assert_eq!(name("Ada\u{200d}Bob"), Ok("Ada\u{200d}Bob".to_owned()));
-        // ZWNJ inside Persian text: لـا written without the ligature.
         assert_eq!(
-            name("\u{644}\u{200c}\u{627}"),
-            Ok("\u{644}\u{200c}\u{627}".to_owned())
+            DisplayName::try_new("Ada\u{200b}"),
+            Err(DisplayNameError(LabelError::DisallowedCharacter))
+        );
+        assert_eq!(
+            DisplayName::try_new("a".repeat(MAX_LABEL_LENGTH + 1)),
+            Err(DisplayNameError(LabelError::TooLong))
         );
     }
 

--- a/apps/cas/src/accounts/display_name.rs
+++ b/apps/cas/src/accounts/display_name.rs
@@ -62,7 +62,7 @@ fn is_zero_width_joiner(c: char) -> bool {
 /// [`validate_display_name`]. NFC still composes decomposed input, so
 /// "e\u{301}" and the Hangul jamo sequence "\u{1100}\u{1161}" become their
 /// precomposed forms.
-fn sanitize_display_name(value: String) -> String {
+pub(crate) fn sanitize_display_name(value: String) -> String {
     let mapped = value
         .chars()
         .map(|c| if is_space_separator(c) { ' ' } else { c })
@@ -137,7 +137,7 @@ fn is_allowed_character(c: char) -> bool {
 /// Marks need a preceding base, selectors must immediately follow a base, and
 /// joiners need a base on both sides. A mark or selector may precede a joiner
 /// (as in emoji and Indic text), but cannot supply the base itself.
-fn validate_display_name(value: &str) -> Result<(), DisplayNameError> {
+pub(crate) fn validate_display_name(value: &str) -> Result<(), DisplayNameError> {
     if value.is_empty() {
         return Err(DisplayNameError::Empty);
     }

--- a/apps/cas/src/accounts/mod.rs
+++ b/apps/cas/src/accounts/mod.rs
@@ -12,6 +12,10 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 pub use display_name::{DisplayName, DisplayNameError, MAX_DISPLAY_NAME_LENGTH};
+/// The rules behind `DisplayName`, for another user-facing label that must
+/// be shown as-is (a passkey's name) and wants the same sanitising and the
+/// same rejections without a second copy of the Unicode reasoning.
+pub(crate) use display_name::{sanitize_display_name, validate_display_name};
 pub use repository::AccountRepository;
 pub(crate) use repository::{get, insert, touch_last_seen};
 

--- a/apps/cas/src/accounts/mod.rs
+++ b/apps/cas/src/accounts/mod.rs
@@ -11,11 +11,7 @@ mod repository;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-pub use display_name::{DisplayName, DisplayNameError, MAX_DISPLAY_NAME_LENGTH};
-/// The rules behind `DisplayName`, for another user-facing label that must
-/// be shown as-is (a passkey's name) and wants the same sanitising and the
-/// same rejections without a second copy of the Unicode reasoning.
-pub(crate) use display_name::{sanitize_display_name, validate_display_name};
+pub use display_name::{DisplayName, DisplayNameError};
 pub use repository::AccountRepository;
 pub(crate) use repository::{get, insert, touch_last_seen};
 

--- a/apps/cas/src/http/error.rs
+++ b/apps/cas/src/http/error.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    extract::rejection::JsonRejection,
+    extract::rejection::{JsonRejection, PathRejection},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -91,6 +91,21 @@ impl From<JsonRejection> for ApiError {
         Self {
             status: rejection.status(),
             code: "invalid_body",
+            message: rejection.body_text(),
+            source: None,
+        }
+    }
+}
+
+/// Renders `Path` extractor rejections (a segment that does not parse into
+/// the handler's type) in the standard error shape. The status is the
+/// rejection's own: 400 for a bad value, 500 for a route whose parameters do
+/// not match its handler, which is a bug.
+impl From<PathRejection> for ApiError {
+    fn from(rejection: PathRejection) -> Self {
+        Self {
+            status: rejection.status(),
+            code: "invalid_path",
             message: rejection.body_text(),
             source: None,
         }

--- a/apps/cas/src/http/extract.rs
+++ b/apps/cas/src/http/extract.rs
@@ -1,4 +1,4 @@
-use axum::extract::FromRequest;
+use axum::extract::{FromRequest, FromRequestParts};
 
 use crate::http::error::ApiError;
 
@@ -8,3 +8,10 @@ use crate::http::error::ApiError;
 #[derive(FromRequest)]
 #[from_request(via(axum::Json), rejection(ApiError))]
 pub struct Json<T>(pub T);
+
+/// Path extractor whose rejections render as [`ApiError`]: a segment that
+/// does not parse (a passkey id that is not a uuid) is a 400 in the standard
+/// shape instead of axum's plain text.
+#[derive(FromRequestParts)]
+#[from_request(via(axum::extract::Path), rejection(ApiError))]
+pub struct Path<T>(pub T);

--- a/apps/cas/src/http/mod.rs
+++ b/apps/cas/src/http/mod.rs
@@ -34,6 +34,7 @@ use crate::sessions::http::CookieSettings;
 use crate::webauthn::build_webauthn;
 use crate::webauthn::http as webauthn_http;
 use crate::webauthn::login::LoginService;
+use crate::webauthn::management::PasskeyManagement;
 use crate::webauthn::registration::RegistrationService;
 
 /// Why the router could not be built. Everything here fails at startup, before
@@ -54,6 +55,7 @@ pub enum AppError {
 pub struct ApiState {
     pub registration: RegistrationService,
     pub login: LoginService,
+    pub passkeys: PasskeyManagement,
     pub sessions: SessionService,
     pub cookies: CookieSettings,
 }
@@ -80,6 +82,7 @@ pub fn app(config: Config) -> Result<NormalizePath<Router>, AppError> {
     let api_state = ApiState {
         registration: RegistrationService::new(webauthn.clone(), pool.clone()),
         login: LoginService::new(webauthn, pool.clone()),
+        passkeys: PasskeyManagement::new(pool.clone()),
         sessions: SessionService::new(pool.clone()),
         cookies: CookieSettings::for_origin(&config.origin),
     };
@@ -108,6 +111,7 @@ pub fn app(config: Config) -> Result<NormalizePath<Router>, AppError> {
 fn api_router(state: ApiState, origins: AllowedOrigins) -> Router {
     let api = Router::new()
         .nest("/webauthn", webauthn_http::router(state.clone()))
+        .nest("/passkeys", webauthn_http::passkeys::router(state.clone()))
         .merge(sessions_http::router(state))
         .fallback(not_found);
 
@@ -243,24 +247,21 @@ mod tests {
         );
     }
 
-    /// The sessions router is nested at `/api` and the webauthn one inside
-    /// that prefix; a request must reach the right one. Both requests fail
-    /// before any query, so no database is needed.
+    /// The sessions router is nested at `/api`, the webauthn and passkeys
+    /// ones inside that prefix; a request must reach the right one. All
+    /// requests fail before any query, so no database is needed.
     #[tokio::test]
     async fn both_contexts_are_reachable_under_the_api_prefix() {
         let app = app(test_config()).unwrap();
 
-        let me = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/api/me")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(me.status(), StatusCode::UNAUTHORIZED);
+        for uri in ["/api/me", "/api/passkeys"] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+        }
 
         let login = app
             .oneshot(

--- a/apps/cas/src/lib.rs
+++ b/apps/cas/src/lib.rs
@@ -6,6 +6,7 @@ pub mod db;
 pub mod http;
 pub mod migrations;
 pub mod sessions;
+pub mod shared;
 #[cfg(test)]
 pub(crate) mod testing;
 pub mod webauthn;

--- a/apps/cas/src/shared/label.rs
+++ b/apps/cas/src/shared/label.rs
@@ -1,0 +1,378 @@
+//! A label: a short user-facing string that a UI shows as-is — an account's
+//! display name, a passkey's name. What is done to it before it is accepted
+//! (space mapping, NFC, trimming) and what is refused (invisible and
+//! direction-changing characters, the empty, the over-long), so that a list,
+//! a sign-in screen or an authenticator prompt can render it without
+//! surprises. The newtypes that use these rules live with their contexts and
+//! carry their own error types; this module only knows about text.
+//!
+//! This deliberately does not use the PRECIS Nickname profile
+//! (`precis-profiles`). That crate's 0.1.13 space trimming indexes bytes with a
+//! char index, so it panics on "Ада " and swallows interior spaces in
+//! "José  Silva"; it deletes non-ASCII spaces instead of mapping them to
+//! U+0020; and it tests the string class before normalising, so decomposed
+//! Hangul is rejected. The profile itself also rejects U+FE0F and ZWJ
+//! sequences, which rules out most modern emoji — not an option for a game's
+//! display name.
+
+use icu_properties::{
+    CodePointSetData,
+    props::{DefaultIgnorableCodePoint, VariationSelector},
+};
+use unicode_general_category::GeneralCategory;
+use unicode_normalization::UnicodeNormalization;
+
+/// Upper bound on a label, in characters. Long enough for a real name or a
+/// device's name, short enough to keep a list, the sign-in UI and the
+/// authenticator prompt readable.
+pub const MAX_LABEL_LENGTH: usize = 64;
+
+/// Why a string is not a valid label.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LabelError {
+    #[error("must not be empty")]
+    Empty,
+
+    #[error("must be at most {MAX_LABEL_LENGTH} characters")]
+    TooLong,
+
+    /// A code point that must never reach a UI: controls, invisible format
+    /// characters (zero-width space, bidi overrides), line and paragraph
+    /// separators, surrogates, private use, unassigned. No position is
+    /// reported: it could only refer to the sanitised value, which the client
+    /// never sees, so it cannot map it back onto what the user typed.
+    #[error("must not contain control or invisible characters")]
+    DisallowedCharacter,
+}
+
+/// Unicode general category Zs: the space separators. Every one of them is
+/// mapped to ASCII space, following RFC 8266's width mapping, so that trimming
+/// and collapsing see a single kind of space.
+fn is_space_separator(c: char) -> bool {
+    const EN_QUAD_TO_HAIR_SPACE: std::ops::RangeInclusive<char> = '\u{2000}'..='\u{200a}';
+    matches!(
+        c,
+        '\u{20}' | '\u{a0}' | '\u{1680}' | '\u{202f}' | '\u{205f}' | '\u{3000}'
+    ) || EN_QUAD_TO_HAIR_SPACE.contains(&c)
+}
+
+/// Zero width joiner and non-joiner. They are the one part of category Cf a
+/// label needs: emoji ZWJ sequences (👨‍👩‍👧) and Persian/Indic
+/// orthography are built from them.
+const ZERO_WIDTH_JOINERS: [char; 2] = ['\u{200d}', '\u{200c}'];
+
+fn is_zero_width_joiner(c: char) -> bool {
+    ZERO_WIDTH_JOINERS.contains(&c)
+}
+
+/// Normalises a label: every Unicode space separator becomes an ASCII
+/// space, the result is put in NFC, then leading and trailing spaces are
+/// removed and runs of spaces collapse to one.
+///
+/// NFC, not NFKC: compatibility folding would rewrite what the user typed
+/// ("Ada™" → "AdaTM", "①" → "1", "x²" → "x2") for no safety gain, since the
+/// characters that actually mislead are rejected outright by
+/// [`validate_label`]. NFC still composes decomposed input, so
+/// "e\u{301}" and the Hangul jamo sequence "\u{1100}\u{1161}" become their
+/// precomposed forms.
+pub fn sanitize_label(value: String) -> String {
+    let mapped = value
+        .chars()
+        .map(|c| if is_space_separator(c) { ' ' } else { c })
+        .nfc();
+
+    let mut result = String::with_capacity(value.len());
+    let mut pending_space = false;
+    for c in mapped {
+        if c == ' ' {
+            // Held back so that a run of spaces, and a trailing one, never
+            // reach the output.
+            pending_space = !result.is_empty();
+            continue;
+        }
+        if pending_space {
+            result.push(' ');
+            pending_space = false;
+        }
+        result.push(c);
+    }
+    result
+}
+
+fn is_variation_selector(c: char) -> bool {
+    CodePointSetData::new::<VariationSelector>().contains(c)
+}
+
+fn is_combining_mark(c: char) -> bool {
+    matches!(
+        unicode_general_category::get_general_category(c),
+        GeneralCategory::NonspacingMark
+            | GeneralCategory::SpacingMark
+            | GeneralCategory::EnclosingMark
+    )
+}
+
+/// A base for combining marks and selectors, or the right side of a joiner.
+/// Unicode properties describe characters, not font-specific glyph coverage.
+fn is_visible_base(c: char) -> bool {
+    is_allowed_character(c)
+        && c != ' '
+        && !is_combining_mark(c)
+        && !CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(c)
+}
+
+/// General categories alone miss invisibles such as CGJ and Hangul fillers.
+/// Use Unicode's Default_Ignorable_Code_Point property as well, with contextual
+/// exceptions for joiners and variation selectors below.
+fn is_allowed_character(c: char) -> bool {
+    if is_zero_width_joiner(c) || is_variation_selector(c) {
+        return true;
+    }
+    // Braille Pattern Blank has no dots, but is a symbol rather than a space
+    // or default-ignorable character in Unicode.
+    c != '\u{2800}'
+        && !CodePointSetData::new::<DefaultIgnorableCodePoint>().contains(c)
+        && !matches!(
+            unicode_general_category::get_general_category(c),
+            GeneralCategory::Control
+                | GeneralCategory::Format
+                | GeneralCategory::LineSeparator
+                | GeneralCategory::ParagraphSeparator
+                | GeneralCategory::Surrogate
+                | GeneralCategory::PrivateUse
+                | GeneralCategory::Unassigned
+        )
+}
+
+/// Rejects anything invisible or direction-changing, then the empty and the
+/// over-long. Runs on the sanitised value.
+///
+/// Marks need a preceding base, selectors must immediately follow a base, and
+/// joiners need a base on both sides. A mark or selector may precede a joiner
+/// (as in emoji and Indic text), but cannot supply the base itself.
+pub fn validate_label(value: &str) -> Result<(), LabelError> {
+    if value.is_empty() {
+        return Err(LabelError::Empty);
+    }
+    if value.chars().count() > MAX_LABEL_LENGTH {
+        return Err(LabelError::TooLong);
+    }
+
+    let mut previous: Option<char> = None;
+    let mut has_base = false;
+    let mut characters = value.chars().peekable();
+    while let Some(c) = characters.next() {
+        if !is_allowed_character(c) {
+            return Err(LabelError::DisallowedCharacter);
+        }
+        if c == ' ' {
+            has_base = false;
+        } else if is_variation_selector(c) {
+            if !previous.is_some_and(is_visible_base) {
+                return Err(LabelError::DisallowedCharacter);
+            }
+        } else if is_zero_width_joiner(c) {
+            if !has_base || !characters.peek().copied().is_some_and(is_visible_base) {
+                return Err(LabelError::DisallowedCharacter);
+            }
+            has_base = false;
+        } else if is_combining_mark(c) {
+            if !has_base {
+                return Err(LabelError::DisallowedCharacter);
+            }
+        } else {
+            has_base = true;
+        }
+        previous = Some(c);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rules the way a newtype applies them: sanitise, then validate.
+    fn name(value: &str) -> Result<String, LabelError> {
+        let value = sanitize_label(value.to_owned());
+        validate_label(&value).map(|()| value)
+    }
+
+    #[test]
+    fn keeps_an_ordinary_name() {
+        for value in ["Ada Lovelace", "Ада", "Zoë", "O'Brien", "Jean-Luc", "李雷"] {
+            assert_eq!(name(value), Ok(value.to_owned()));
+        }
+    }
+
+    /// Emoji are made of exactly the characters a naive "no invisibles" rule
+    /// throws away: U+FE0F, skin tone modifiers, the keycap combining mark and
+    /// the zero width joiner.
+    #[test]
+    fn keeps_emoji() {
+        for value in [
+            "Ada 🚀",
+            "Ada \u{2764}\u{fe0f}",
+            "Ada 👨\u{200d}👩\u{200d}👧",
+            "👍🏽 Ada",
+            "1\u{fe0f}\u{20e3}",
+            "👩\u{200d}❤️\u{200d}👩",
+            "🏳\u{fe0f}\u{200d}🌈",
+        ] {
+            assert_eq!(name(value), Ok(value.to_owned()));
+        }
+    }
+
+    #[test]
+    fn trims_and_collapses_spaces() {
+        assert_eq!(name("  Ada   Lovelace  "), Ok("Ada Lovelace".to_owned()));
+        // Non-ASCII spaces become ASCII ones and collapse with them.
+        assert_eq!(name("Ada\u{a0}Lovelace"), Ok("Ada Lovelace".to_owned()));
+        assert_eq!(
+            name("Ada\u{3000} \u{2003}Lovelace"),
+            Ok("Ada Lovelace".to_owned())
+        );
+        assert_eq!(name("\u{a0}Ada\u{a0}"), Ok("Ada".to_owned()));
+        // Trimming works on characters, not bytes: a multi-byte name followed
+        // by a space is not truncated, and interior spaces survive.
+        assert_eq!(name("Ада "), Ok("Ада".to_owned()));
+        assert_eq!(name("Zoë "), Ok("Zoë".to_owned()));
+        assert_eq!(name("José  Silva"), Ok("José Silva".to_owned()));
+    }
+
+    /// NFC composes decomposed input but, unlike NFKC, leaves compatibility
+    /// characters alone: they are what the user typed and none of them can
+    /// impersonate another name.
+    #[test]
+    fn normalises_to_nfc() {
+        assert_eq!(name("e\u{301}"), Ok("\u{e9}".to_owned()));
+        // Conjoining Hangul jamo compose into the syllable 가.
+        assert_eq!(name("\u{1100}\u{1161}"), Ok("\u{ac00}".to_owned()));
+
+        for value in ["Ada™", "①", "ﬁsh", "x²"] {
+            assert_eq!(name(value), Ok(value.to_owned()));
+        }
+    }
+
+    #[test]
+    fn rejects_empty_names() {
+        assert_eq!(name(""), Err(LabelError::Empty));
+        assert_eq!(name("   "), Err(LabelError::Empty));
+        assert_eq!(name("\u{a0}"), Err(LabelError::Empty));
+    }
+
+    #[test]
+    fn rejects_names_over_the_limit() {
+        assert!(name(&"a".repeat(MAX_LABEL_LENGTH)).is_ok());
+        assert_eq!(
+            name(&"a".repeat(MAX_LABEL_LENGTH + 1)),
+            Err(LabelError::TooLong)
+        );
+    }
+
+    /// Invisible and direction-changing characters would let a name render as
+    /// empty or as another name in the authenticator prompt. Surrogates are
+    /// not covered: a Rust `str` cannot hold one.
+    #[test]
+    fn rejects_control_and_format_characters() {
+        for value in [
+            "Ada\u{7}",
+            "\u{200b}",
+            "Ada\u{200b}",
+            "\u{202e}adA",
+            "\u{feff}Ada",
+            "\u{2028}Ada",
+            "Ada\u{e000}",
+        ] {
+            assert_eq!(
+                name(value),
+                Err(LabelError::DisallowedCharacter),
+                "{value:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_invisibles_outside_the_format_category() {
+        for invisible in [
+            '\u{034f}', '\u{115f}', '\u{1160}', '\u{17b4}', '\u{17b5}', '\u{2800}', '\u{3164}',
+            '\u{ffa0}',
+        ] {
+            for value in [
+                invisible.to_string(),
+                format!("Ada{invisible}"),
+                format!("A{invisible}B"),
+            ] {
+                assert_eq!(
+                    name(&value),
+                    Err(LabelError::DisallowedCharacter),
+                    "{value:?} must be rejected"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_selectors_and_marks_without_a_base() {
+        for value in [
+            "\u{fe0f}",
+            "\u{e0100}",
+            "\u{180b}",
+            "\u{fe0f}Ada",
+            "Ada \u{fe0f}",
+            "A\u{fe0f}\u{fe0f}",
+            "\u{301}",
+            "Ada \u{301}",
+            "\u{fe0f}\u{200d}\u{fe0f}",
+            "A\u{200d}\u{fe0f}",
+            "A\u{200d}\u{301}B",
+        ] {
+            assert_eq!(
+                name(value),
+                Err(LabelError::DisallowedCharacter),
+                "{value:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_marks_and_selectors_with_a_base() {
+        for value in [
+            "q\u{301}\u{302}",
+            "\u{4e00}\u{e0100}",
+            "\u{1820}\u{180b}",
+            "\u{915}\u{94d}\u{200d}\u{937}",
+        ] {
+            assert_eq!(name(value), Ok(value.to_owned()));
+        }
+    }
+
+    /// A zero width joiner is only allowed where it joins two visible
+    /// characters; anywhere else it is invisible padding.
+    #[test]
+    fn rejects_a_joiner_with_nothing_to_join() {
+        for value in [
+            "\u{200d}Ada",
+            "Ada\u{200d}",
+            "Ada\u{200d}\u{200d}Bob",
+            "Ada \u{200d}Bob",
+        ] {
+            assert_eq!(
+                name(value),
+                Err(LabelError::DisallowedCharacter),
+                "{value:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_joiners_between_letters() {
+        assert_eq!(name("Ada\u{200d}Bob"), Ok("Ada\u{200d}Bob".to_owned()));
+        // ZWNJ inside Persian text: لـا written without the ligature.
+        assert_eq!(
+            name("\u{644}\u{200c}\u{627}"),
+            Ok("\u{644}\u{200c}\u{627}".to_owned())
+        );
+    }
+}

--- a/apps/cas/src/shared/mod.rs
+++ b/apps/cas/src/shared/mod.rs
@@ -1,0 +1,7 @@
+//! Shared vocabulary: types and rules that more than one bounded context
+//! needs and none of them owns. Only domain-level, context-free material
+//! belongs here — no axum, no SQL, no configuration (that is `config`, `db`
+//! and `migrations`). Contexts depend on this module; it depends on nothing
+//! of theirs.
+
+pub mod label;

--- a/apps/cas/src/testing.rs
+++ b/apps/cas/src/testing.rs
@@ -23,6 +23,7 @@ use crate::sessions::http::CookieSettings;
 use crate::sessions::{SessionService, SessionToken};
 use crate::webauthn::build_webauthn;
 use crate::webauthn::login::LoginService;
+use crate::webauthn::management::PasskeyManagement;
 use crate::webauthn::registration::{
     Registered, RegistrationService, start_discoverable_registration,
 };
@@ -33,6 +34,7 @@ pub fn test_state(pool: PgPool) -> ApiState {
     ApiState {
         registration: RegistrationService::new(test_webauthn(), pool.clone()),
         login: LoginService::new(test_webauthn(), pool.clone()),
+        passkeys: PasskeyManagement::new(pool.clone()),
         sessions: SessionService::new(pool),
         cookies: CookieSettings::for_origin(&test_origin()),
     }

--- a/apps/cas/src/webauthn/http/mod.rs
+++ b/apps/cas/src/webauthn/http/mod.rs
@@ -1,7 +1,10 @@
-//! `/api/webauthn` — the passkey ceremony endpoints. Mounted by the transport
-//! root in `crate::http`; the only part of the context that knows axum.
+//! The context's endpoints: `/api/webauthn`, the passkey ceremonies, and
+//! `/api/passkeys`, the signed-in account's passkeys. Both mounted by the
+//! transport root in `crate::http`; the only part of the context that knows
+//! axum.
 
 pub mod login;
+pub mod passkeys;
 pub mod registration;
 
 use axum::{Router, routing::post};

--- a/apps/cas/src/webauthn/http/passkeys.rs
+++ b/apps/cas/src/webauthn/http/passkeys.rs
@@ -1,0 +1,378 @@
+//! `/api/passkeys` — the signed-in account's passkeys: list, rename, delete.
+//! Every handler takes `Authenticated`, so an anonymous request is a 401
+//! before anything here runs, and the account id comes from the session,
+//! never from the request.
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    routing::{get, patch},
+};
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::http::ApiState;
+use crate::http::error::ApiError;
+use crate::http::extract::{Json as AppJson, Path};
+use crate::sessions::Authenticated;
+use crate::webauthn::management::ManagementError;
+use crate::webauthn::passkeys::{PasskeyCredential, PasskeyName, PasskeyNameError};
+
+/// The name is validated by the handler rather than by the body type, so a bad
+/// one gets this code instead of a generic `invalid_body`.
+impl From<PasskeyNameError> for ApiError {
+    fn from(error: PasskeyNameError) -> Self {
+        ApiError::bad_request(
+            "invalid_passkey_name",
+            format!("Invalid passkey name: {error}"),
+        )
+    }
+}
+
+impl From<ManagementError> for ApiError {
+    fn from(error: ManagementError) -> Self {
+        let message = error.to_string();
+        match error {
+            ManagementError::NotFound => ApiError::not_found("passkey_not_found", message),
+            // A conflict with the account's state, not a bad request: the
+            // same request succeeds once another passkey exists.
+            ManagementError::LastPasskey => ApiError::conflict("last_passkey", message),
+            ManagementError::Db(error) => ApiError::from(error),
+        }
+    }
+}
+
+pub fn router(state: ApiState) -> Router {
+    Router::new()
+        .route("/", get(list))
+        .route("/{id}", patch(rename).delete(delete))
+        .with_state(state)
+}
+
+/// A passkey as the dashboard shows it. The credential itself (public key,
+/// counter, flags) is server-side state and never leaves.
+#[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasskeyResponse {
+    id: Uuid,
+    name: String,
+    #[serde(with = "time::serde::rfc3339")]
+    created_at: OffsetDateTime,
+    /// `null` until the passkey is first used to sign in.
+    #[serde(with = "time::serde::rfc3339::option")]
+    last_used_at: Option<OffsetDateTime>,
+}
+
+impl From<PasskeyCredential> for PasskeyResponse {
+    fn from(credential: PasskeyCredential) -> Self {
+        Self {
+            id: credential.id,
+            name: credential.name,
+            created_at: credential.created_at,
+            last_used_at: credential.last_used_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PasskeyListResponse {
+    passkeys: Vec<PasskeyResponse>,
+}
+
+#[derive(Debug, Serialize, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenamePasskeyRequest {
+    /// Validated by the handler rather than by the type, so a bad name gets
+    /// its own error code instead of a generic `invalid_body`.
+    name: String,
+}
+
+async fn list(
+    State(state): State<ApiState>,
+    authenticated: Authenticated,
+) -> Result<Json<PasskeyListResponse>, ApiError> {
+    let passkeys = state.passkeys.list(authenticated.account.id).await?;
+
+    Ok(Json(PasskeyListResponse {
+        passkeys: passkeys.into_iter().map(Into::into).collect(),
+    }))
+}
+
+async fn rename(
+    State(state): State<ApiState>,
+    authenticated: Authenticated,
+    Path(id): Path<Uuid>,
+    AppJson(request): AppJson<RenamePasskeyRequest>,
+) -> Result<Json<PasskeyResponse>, ApiError> {
+    let name = PasskeyName::try_new(request.name)?;
+
+    let renamed = state
+        .passkeys
+        .rename(authenticated.account.id, id, name)
+        .await?;
+
+    Ok(Json(renamed.into()))
+}
+
+async fn delete(
+    State(state): State<ApiState>,
+    authenticated: Authenticated,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    state.passkeys.delete(authenticated.account.id, id).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Request, header},
+    };
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::sessions::SessionService;
+    use crate::sessions::http::cookie::SESSION_COOKIE;
+    use crate::testing::{register_soft_passkey, test_passkey, test_state};
+    use crate::webauthn::passkeys::DEFAULT_PASSKEY_NAME;
+    use crate::webauthn::repository::insert_passkey;
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// A signed-in account with its registration passkey: the cookie header,
+    /// the account id and the passkey id.
+    async fn signed_in(pool: &PgPool) -> (String, Uuid, Uuid) {
+        let (_, registered) = register_soft_passkey(pool).await;
+        let issued = SessionService::new(pool.clone())
+            .create(registered.account.id)
+            .await
+            .unwrap();
+        (
+            format!("{SESSION_COOKIE}={}", issued.token.expose()),
+            registered.account.id,
+            registered.credential.id,
+        )
+    }
+
+    fn request(method: &str, uri: &str, cookie: Option<&str>, body: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder().method(method).uri(uri);
+        if let Some(cookie) = cookie {
+            request = request.header(header::COOKIE, cookie);
+        }
+        match body {
+            Some(body) => request
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_owned()))
+                .unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        }
+    }
+
+    #[sqlx::test]
+    async fn every_endpoint_needs_a_session(pool: PgPool) {
+        let app = router(test_state(pool));
+        let id = Uuid::new_v4();
+
+        for (method, uri, body) in [
+            ("GET", "/".to_owned(), None),
+            ("PATCH", format!("/{id}"), Some(r#"{"name":"x"}"#)),
+            ("DELETE", format!("/{id}"), None),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(request(method, &uri, None, body))
+                .await
+                .unwrap();
+
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{method} {uri}"
+            );
+            assert_eq!(
+                body_json(response).await["error"]["code"],
+                "unauthenticated"
+            );
+        }
+    }
+
+    #[sqlx::test]
+    async fn list_shows_name_created_at_and_last_used_at(pool: PgPool) {
+        let (cookie, account_id, passkey_id) = signed_in(&pool).await;
+        insert_passkey(&pool, account_id, &test_passkey(), "Second")
+            .await
+            .unwrap();
+
+        let response = router(test_state(pool))
+            .oneshot(request("GET", "/", Some(&cookie), None))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let passkeys = body["passkeys"].as_array().unwrap();
+        assert_eq!(passkeys.len(), 2);
+        assert_eq!(passkeys[0]["id"], passkey_id.to_string());
+        assert_eq!(passkeys[0]["name"], DEFAULT_PASSKEY_NAME);
+        assert!(passkeys[0]["createdAt"].is_string());
+        assert!(passkeys[0]["lastUsedAt"].is_null(), "never used to sign in");
+        assert_eq!(passkeys[1]["name"], "Second");
+        assert!(
+            passkeys[0].get("credential").is_none() && passkeys[0].get("credentialId").is_none(),
+            "the credential stays server-side"
+        );
+    }
+
+    #[sqlx::test]
+    async fn rename_returns_the_renamed_passkey(pool: PgPool) {
+        let (cookie, _, passkey_id) = signed_in(&pool).await;
+
+        let response = router(test_state(pool))
+            .oneshot(request(
+                "PATCH",
+                &format!("/{passkey_id}"),
+                Some(&cookie),
+                Some(r#"{"name":"  My YubiKey "}"#),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["id"], passkey_id.to_string());
+        assert_eq!(body["name"], "My YubiKey", "sanitised like a display name");
+    }
+
+    #[sqlx::test]
+    async fn rename_refuses_an_invalid_name(pool: PgPool) {
+        let (cookie, _, passkey_id) = signed_in(&pool).await;
+        let app = router(test_state(pool));
+
+        for body in [r#"{"name":""}"#, "{\"name\":\"a\u{200b}b\"}"] {
+            let response = app
+                .clone()
+                .oneshot(request(
+                    "PATCH",
+                    &format!("/{passkey_id}"),
+                    Some(&cookie),
+                    Some(body),
+                ))
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{body}");
+            assert_eq!(
+                body_json(response).await["error"]["code"],
+                "invalid_passkey_name"
+            );
+        }
+    }
+
+    /// Someone else's passkey and no passkey at all get the same answer.
+    #[sqlx::test]
+    async fn rename_and_delete_of_a_passkey_that_is_not_yours_is_404(pool: PgPool) {
+        let (cookie, _, _) = signed_in(&pool).await;
+        let (_, other) = register_soft_passkey(&pool).await;
+        let app = router(test_state(pool));
+
+        for id in [other.credential.id, Uuid::new_v4()] {
+            for (method, body) in [("PATCH", Some(r#"{"name":"Mine"}"#)), ("DELETE", None)] {
+                let response = app
+                    .clone()
+                    .oneshot(request(method, &format!("/{id}"), Some(&cookie), body))
+                    .await
+                    .unwrap();
+
+                assert_eq!(response.status(), StatusCode::NOT_FOUND, "{method} {id}");
+                assert_eq!(
+                    body_json(response).await["error"]["code"],
+                    "passkey_not_found"
+                );
+            }
+        }
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_a_passkey_and_keeps_the_session(pool: PgPool) {
+        let (cookie, account_id, passkey_id) = signed_in(&pool).await;
+        insert_passkey(&pool, account_id, &test_passkey(), "Second")
+            .await
+            .unwrap();
+        let app = router(test_state(pool));
+
+        let response = app
+            .clone()
+            .oneshot(request(
+                "DELETE",
+                &format!("/{passkey_id}"),
+                Some(&cookie),
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        let list = app
+            .oneshot(request("GET", "/", Some(&cookie), None))
+            .await
+            .unwrap();
+        assert_eq!(
+            list.status(),
+            StatusCode::OK,
+            "the session opened with it lives on"
+        );
+        let body = body_json(list).await;
+        assert_eq!(body["passkeys"].as_array().unwrap().len(), 1);
+        assert_eq!(body["passkeys"][0]["name"], "Second");
+    }
+
+    #[sqlx::test]
+    async fn deleting_the_last_passkey_is_a_conflict(pool: PgPool) {
+        let (cookie, _, passkey_id) = signed_in(&pool).await;
+
+        let response = router(test_state(pool))
+            .oneshot(request(
+                "DELETE",
+                &format!("/{passkey_id}"),
+                Some(&cookie),
+                None,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = body_json(response).await;
+        assert_eq!(body["error"]["code"], "last_passkey");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("add another one first"),
+            "{body}"
+        );
+    }
+
+    /// A path segment that is not a uuid is a 400 in the standard shape, not
+    /// axum's plain-text rejection.
+    #[sqlx::test]
+    async fn a_malformed_passkey_id_is_a_bad_request(pool: PgPool) {
+        let (cookie, _, _) = signed_in(&pool).await;
+
+        let response = router(test_state(pool))
+            .oneshot(request("DELETE", "/not-a-uuid", Some(&cookie), None))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(response).await["error"]["code"], "invalid_path");
+    }
+}

--- a/apps/cas/src/webauthn/management.rs
+++ b/apps/cas/src/webauthn/management.rs
@@ -1,0 +1,242 @@
+//! Passkey management: what a signed-in account may do to its own passkeys.
+//!
+//! List, rename and delete, each scoped to the account the session names: a
+//! passkey that belongs to someone else does not exist as far as this service
+//! is concerned. Deleting the last passkey is refused. There is no recovery
+//! in v1 (`docs/PLAN.md`), so an account without a passkey could never be
+//! signed into again; a second passkey is the safety net, and the rule keeps
+//! it from being kicked away. See `docs/adr/0006-passkey-management.md`.
+
+use sqlx::PgPool;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::webauthn::passkeys::{PasskeyCredential, PasskeyName};
+use crate::webauthn::repository::{self, PasskeyRepository};
+
+#[derive(Debug, Error)]
+pub enum ManagementError {
+    /// No passkey with that id belongs to the account. Someone else's passkey
+    /// is reported the same way as no passkey at all: a caller learns nothing
+    /// about ids it does not own.
+    #[error("passkey not found")]
+    NotFound,
+
+    /// The account has exactly one passkey and it is the one to delete. With
+    /// no recovery in v1, removing it would lock the account out for good.
+    #[error("the last passkey cannot be removed; add another one first")]
+    LastPasskey,
+
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct PasskeyManagement {
+    passkeys: PasskeyRepository,
+    pool: PgPool,
+}
+
+impl PasskeyManagement {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            passkeys: PasskeyRepository::new(pool.clone()),
+            pool,
+        }
+    }
+
+    /// The account's passkeys, oldest first.
+    pub async fn list(&self, account_id: Uuid) -> Result<Vec<PasskeyCredential>, sqlx::Error> {
+        self.passkeys.list_for_account(account_id).await
+    }
+
+    /// Renames one of the account's passkeys and returns it as stored.
+    pub async fn rename(
+        &self,
+        account_id: Uuid,
+        passkey_id: Uuid,
+        name: PasskeyName,
+    ) -> Result<PasskeyCredential, ManagementError> {
+        let renamed = repository::rename_passkey(&self.pool, passkey_id, account_id, &name)
+            .await?
+            .ok_or(ManagementError::NotFound)?;
+
+        tracing::debug!(passkey_id = %passkey_id, account_id = %account_id, "passkey renamed");
+        Ok(renamed)
+    }
+
+    /// Deletes one of the account's passkeys, unless it is the last one.
+    ///
+    /// The account's passkey rows are locked first, so two deletes running
+    /// at once cannot both count two passkeys and both proceed: the second
+    /// waits, then counts what the first left. Sessions opened with the
+    /// deleted passkey are untouched (ADR 0004): a passkey is a way in, not
+    /// the session itself.
+    pub async fn delete(&self, account_id: Uuid, passkey_id: Uuid) -> Result<(), ManagementError> {
+        let mut tx = self.pool.begin().await?;
+
+        let owned = repository::lock_passkeys(&mut *tx, account_id).await?;
+        if !owned.contains(&passkey_id) {
+            return Err(ManagementError::NotFound);
+        }
+        if owned.len() == 1 {
+            return Err(ManagementError::LastPasskey);
+        }
+        // The row is locked and known to be the account's; a miss here would
+        // be a bug in the lock, and treating it as "not found" is the honest
+        // answer if it ever happened.
+        if !repository::delete_passkey(&mut *tx, passkey_id, account_id).await? {
+            return Err(ManagementError::NotFound);
+        }
+        tx.commit().await?;
+
+        tracing::info!(passkey_id = %passkey_id, account_id = %account_id, "passkey deleted");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::{register_soft_passkey, test_passkey};
+    use crate::webauthn::passkeys::DEFAULT_PASSKEY_NAME;
+
+    fn name(value: &str) -> PasskeyName {
+        PasskeyName::try_new(value).unwrap()
+    }
+
+    /// An account with its registration passkey and one more, the way the
+    /// dashboard's "add a passkey" will leave it.
+    async fn account_with_two_passkeys(pool: &PgPool) -> (Uuid, Uuid, Uuid) {
+        let (_, registered) = register_soft_passkey(pool).await;
+        let second =
+            repository::insert_passkey(pool, registered.account.id, &test_passkey(), "Second")
+                .await
+                .unwrap();
+        (registered.account.id, registered.credential.id, second.id)
+    }
+
+    #[sqlx::test]
+    async fn list_shows_the_account_passkeys_oldest_first(pool: PgPool) {
+        let (account_id, first, second) = account_with_two_passkeys(&pool).await;
+        let service = PasskeyManagement::new(pool);
+
+        let listed = service.list(account_id).await.unwrap();
+
+        assert_eq!(
+            listed.iter().map(|p| p.id).collect::<Vec<_>>(),
+            [first, second]
+        );
+        assert_eq!(listed[0].name, DEFAULT_PASSKEY_NAME);
+        assert_eq!(listed[1].name, "Second");
+        assert!(service.list(Uuid::new_v4()).await.unwrap().is_empty());
+    }
+
+    #[sqlx::test]
+    async fn rename_works_on_own_passkeys_only(pool: PgPool) {
+        let (account_id, first, _) = account_with_two_passkeys(&pool).await;
+        let (_, other) = register_soft_passkey(&pool).await;
+        let service = PasskeyManagement::new(pool);
+
+        let renamed = service
+            .rename(account_id, first, name("MacBook"))
+            .await
+            .unwrap();
+        assert_eq!(renamed.id, first);
+        assert_eq!(renamed.name, "MacBook");
+
+        let error = service
+            .rename(account_id, other.credential.id, name("Mine now"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ManagementError::NotFound));
+        let error = service
+            .rename(account_id, Uuid::new_v4(), name("Ghost"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ManagementError::NotFound));
+        assert_eq!(
+            service.list(other.account.id).await.unwrap()[0].name,
+            DEFAULT_PASSKEY_NAME,
+            "the other account's passkey kept its name"
+        );
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_a_passkey_that_is_not_the_last(pool: PgPool) {
+        let (account_id, first, second) = account_with_two_passkeys(&pool).await;
+        let service = PasskeyManagement::new(pool);
+
+        service.delete(account_id, first).await.unwrap();
+
+        let left = service.list(account_id).await.unwrap();
+        assert_eq!(left.iter().map(|p| p.id).collect::<Vec<_>>(), [second]);
+        let error = service.delete(account_id, first).await.unwrap_err();
+        assert!(matches!(error, ManagementError::NotFound), "gone is gone");
+    }
+
+    #[sqlx::test]
+    async fn the_last_passkey_cannot_be_deleted(pool: PgPool) {
+        let (_, registered) = register_soft_passkey(&pool).await;
+        let service = PasskeyManagement::new(pool);
+
+        let error = service
+            .delete(registered.account.id, registered.credential.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ManagementError::LastPasskey));
+        assert_eq!(service.list(registered.account.id).await.unwrap().len(), 1);
+    }
+
+    #[sqlx::test]
+    async fn delete_refuses_someone_elses_passkey(pool: PgPool) {
+        let (account_id, _, _) = account_with_two_passkeys(&pool).await;
+        let (_, other) = register_soft_passkey(&pool).await;
+        let service = PasskeyManagement::new(pool);
+
+        let error = service
+            .delete(account_id, other.credential.id)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ManagementError::NotFound));
+        assert_eq!(service.list(other.account.id).await.unwrap().len(), 1);
+    }
+
+    /// Two deletes of the two remaining passkeys at once. Both are held at
+    /// the row lock taken here, so both start from "two left"; on release,
+    /// one deletes and the other finds one left and is refused.
+    #[sqlx::test]
+    async fn concurrent_deletes_leave_one_passkey(pool: PgPool) {
+        let (account_id, first, second) = account_with_two_passkeys(&pool).await;
+        let service = PasskeyManagement::new(pool.clone());
+
+        let mut lock = pool.begin().await.unwrap();
+        repository::lock_passkeys(&mut *lock, account_id)
+            .await
+            .unwrap();
+        let deletes: Vec<_> = [first, second]
+            .into_iter()
+            .map(|id| {
+                let service = service.clone();
+                tokio::spawn(async move { service.delete(account_id, id).await })
+            })
+            .collect();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        lock.commit().await.unwrap();
+
+        let mut deleted = 0;
+        let mut refused = 0;
+        for delete in deletes {
+            match delete.await.unwrap() {
+                Ok(()) => deleted += 1,
+                Err(ManagementError::LastPasskey) => refused += 1,
+                Err(error) => panic!("unexpected: {error}"),
+            }
+        }
+
+        assert_eq!((deleted, refused), (1, 1));
+        assert_eq!(service.list(account_id).await.unwrap().len(), 1);
+    }
+}

--- a/apps/cas/src/webauthn/mod.rs
+++ b/apps/cas/src/webauthn/mod.rs
@@ -1,8 +1,9 @@
 //! WebAuthn — the passkey bounded context: the ceremonies the server remembers
 //! between two requests ([`ceremonies`]), the flows that drive them
 //! ([`registration`], [`login`]), the credentials they store and verify
-//! ([`passkeys`]), the queries behind all of it ([`repository`]) and the
-//! endpoints that expose it ([`http`]).
+//! ([`passkeys`]) and what an account may do to its own ([`management`]), the
+//! queries behind all of it ([`repository`]) and the endpoints that expose it
+//! ([`http`]).
 
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ use webauthn_rs::prelude::{Url, Webauthn, WebauthnBuilder, WebauthnError};
 pub mod ceremonies;
 pub mod http;
 pub mod login;
+pub mod management;
 pub mod passkeys;
 pub mod registration;
 pub mod repository;

--- a/apps/cas/src/webauthn/passkeys.rs
+++ b/apps/cas/src/webauthn/passkeys.rs
@@ -13,28 +13,29 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 use webauthn_rs::prelude::Passkey;
 
-use crate::accounts::{DisplayNameError, sanitize_display_name, validate_display_name};
+use crate::shared::label::{LabelError, sanitize_label, validate_label};
 
 /// Label given to the passkey created during registration. The user has not
 /// been asked for one at that point; passkey management lets them rename it.
 pub const DEFAULT_PASSKEY_NAME: &str = "Passkey";
 
-/// Why a string is not a [`PasskeyName`]: the same reasons a string is not a
-/// display name, since both are labels a UI shows as-is.
+/// Why a string is not a [`PasskeyName`]: the label rules, under a name of
+/// this context's own so the transport can give it its own error code.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[error(transparent)]
-pub struct PasskeyNameError(DisplayNameError);
+pub struct PasskeyNameError(LabelError);
 
 fn validate_passkey_name(value: &str) -> Result<(), PasskeyNameError> {
-    validate_display_name(value).map_err(PasskeyNameError)
+    validate_label(value).map_err(PasskeyNameError)
 }
 
 /// The user-facing label of a passkey ("MacBook", "YubiKey"), valid by
-/// construction under the display name rules: sanitised spaces and NFC, no
-/// invisible or direction-changing characters, at most the display name's
-/// length. Not unique: naming two keys alike is the user's business.
+/// construction under the shared label rules (`crate::shared::label`):
+/// sanitised spaces and NFC, no invisible or direction-changing characters,
+/// the same length cap as a display name. Not unique: naming two keys alike
+/// is the user's business.
 #[nutype(
-    sanitize(with = sanitize_display_name),
+    sanitize(with = sanitize_label),
     validate(with = validate_passkey_name, error = PasskeyNameError),
     derive(Debug, Clone, PartialEq, Eq, AsRef, Deref, Display, Into, Serialize, Deserialize),
 )]
@@ -87,7 +88,7 @@ mod passkey_name_tests {
     }
 
     #[test]
-    fn a_name_is_sanitised_like_a_display_name() {
+    fn a_name_is_a_sanitised_valid_label() {
         assert_eq!(
             PasskeyName::try_new("  My\u{a0} YubiKey  ").map(Into::<String>::into),
             Ok("My YubiKey".to_owned())

--- a/apps/cas/src/webauthn/passkeys.rs
+++ b/apps/cas/src/webauthn/passkeys.rs
@@ -7,15 +7,38 @@
 //! `docs/adr/0001-passkey-persistence.md`. The queries themselves live in
 //! [`repository`](crate::webauthn::repository).
 
+use nutype::nutype;
 use thiserror::Error;
 use time::OffsetDateTime;
 use uuid::Uuid;
 use webauthn_rs::prelude::Passkey;
 
+use crate::accounts::{DisplayNameError, sanitize_display_name, validate_display_name};
+
 /// Label given to the passkey created during registration. The user has not
-/// been asked for one at that point; passkey management (#668) lets them
-/// rename it.
+/// been asked for one at that point; passkey management lets them rename it.
 pub const DEFAULT_PASSKEY_NAME: &str = "Passkey";
+
+/// Why a string is not a [`PasskeyName`]: the same reasons a string is not a
+/// display name, since both are labels a UI shows as-is.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error(transparent)]
+pub struct PasskeyNameError(DisplayNameError);
+
+fn validate_passkey_name(value: &str) -> Result<(), PasskeyNameError> {
+    validate_display_name(value).map_err(PasskeyNameError)
+}
+
+/// The user-facing label of a passkey ("MacBook", "YubiKey"), valid by
+/// construction under the display name rules: sanitised spaces and NFC, no
+/// invisible or direction-changing characters, at most the display name's
+/// length. Not unique: naming two keys alike is the user's business.
+#[nutype(
+    sanitize(with = sanitize_display_name),
+    validate(with = validate_passkey_name, error = PasskeyNameError),
+    derive(Debug, Clone, PartialEq, Eq, AsRef, Deref, Display, Into, Serialize, Deserialize),
+)]
+pub struct PasskeyName(String);
 
 /// A row of `passkey_credentials`.
 ///
@@ -49,4 +72,36 @@ pub enum CreateError {
 
     #[error(transparent)]
     Db(sqlx::Error),
+}
+
+#[cfg(test)]
+mod passkey_name_tests {
+    use super::*;
+
+    #[test]
+    fn the_default_name_is_a_valid_name() {
+        assert_eq!(
+            PasskeyName::try_new(DEFAULT_PASSKEY_NAME).map(Into::<String>::into),
+            Ok(DEFAULT_PASSKEY_NAME.to_owned())
+        );
+    }
+
+    #[test]
+    fn a_name_is_sanitised_like_a_display_name() {
+        assert_eq!(
+            PasskeyName::try_new("  My\u{a0} YubiKey  ").map(Into::<String>::into),
+            Ok("My YubiKey".to_owned())
+        );
+    }
+
+    #[test]
+    fn the_display_name_rejections_apply() {
+        assert!(PasskeyName::try_new("").is_err());
+        assert!(PasskeyName::try_new("   ").is_err());
+        assert!(
+            PasskeyName::try_new("a\u{200b}b").is_err(),
+            "zero-width space"
+        );
+        assert!(PasskeyName::try_new("x".repeat(65)).is_err());
+    }
 }

--- a/apps/cas/src/webauthn/repository.rs
+++ b/apps/cas/src/webauthn/repository.rs
@@ -15,7 +15,7 @@ use webauthn_rs::prelude::Passkey;
 
 use crate::accounts::{self, Account, NewAccount};
 use crate::webauthn::ceremonies::{Ceremony, CeremonyKind, Taken};
-use crate::webauthn::passkeys::{CreateError, PasskeyCredential};
+use crate::webauthn::passkeys::{CreateError, PasskeyCredential, PasskeyName};
 use crate::webauthn::{CEREMONY_GRACE, CEREMONY_TIMEOUT};
 
 // Ceremonies ---------------------------------------------------------------
@@ -257,8 +257,9 @@ pub async fn create_passkey_with_account(
 }
 
 /// Inserts a credential with any executor, so it can join the transaction that
-/// also creates the account.
-async fn insert_passkey<'e, E>(
+/// also creates the account. Adding a passkey to an existing account will be
+/// this same write.
+pub(crate) async fn insert_passkey<'e, E>(
     executor: E,
     account_id: Uuid,
     passkey: &Passkey,
@@ -289,6 +290,84 @@ where
     .fetch_one(executor)
     .await
     .map(Into::into)
+}
+
+/// The ids of an account's passkeys, locked for the rest of the caller's
+/// transaction. Deleting a passkey must know whether it is the last one, and
+/// two deletes running at once must not both see "two left": the lock makes
+/// the second wait, and it then sees the rows as the first left them.
+pub(crate) async fn lock_passkeys<'e, E>(
+    executor: E,
+    account_id: Uuid,
+) -> Result<Vec<Uuid>, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_scalar!(
+        r#"SELECT id FROM passkey_credentials
+           WHERE account_id = $1
+           ORDER BY id
+           FOR UPDATE"#,
+        account_id,
+    )
+    .fetch_all(executor)
+    .await
+}
+
+/// Renames a passkey, if it belongs to the account. `Ok(None)` for a passkey
+/// that does not exist or is someone else's: the query does not tell the two
+/// apart, and neither does the caller.
+pub(crate) async fn rename_passkey<'e, E>(
+    executor: E,
+    id: Uuid,
+    account_id: Uuid,
+    name: &PasskeyName,
+) -> Result<Option<PasskeyCredential>, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    sqlx::query_as!(
+        PasskeyRow,
+        r#"UPDATE passkey_credentials
+           SET name = $3
+           WHERE id = $1 AND account_id = $2
+           RETURNING
+               id,
+               account_id,
+               credential_id,
+               credential AS "credential: Json<Passkey>",
+               name,
+               created_at,
+               last_used_at"#,
+        id,
+        account_id,
+        name.as_ref(),
+    )
+    .fetch_optional(executor)
+    .await
+    .map(|row| row.map(Into::into))
+}
+
+/// Deletes a passkey, if it belongs to the account. `Ok(false)` when no such
+/// row was there. The rule that the last passkey stays is the service's, taken
+/// under [`lock_passkeys`]; this is only the write.
+pub(crate) async fn delete_passkey<'e, E>(
+    executor: E,
+    id: Uuid,
+    account_id: Uuid,
+) -> Result<bool, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let result = sqlx::query!(
+        "DELETE FROM passkey_credentials WHERE id = $1 AND account_id = $2",
+        id,
+        account_id,
+    )
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 #[cfg(test)]
@@ -604,6 +683,94 @@ mod passkey_tests {
         assert_eq!(
             serde_json::to_value(&stored.passkey).unwrap()["cred"]["counter"],
             42
+        );
+    }
+
+    fn name(value: &str) -> PasskeyName {
+        PasskeyName::try_new(value).unwrap()
+    }
+
+    #[sqlx::test]
+    async fn rename_changes_the_name_of_an_owned_passkey_only(pool: PgPool) {
+        let (account, created) = create_committed(
+            &pool,
+            NewAccount::full(display_name("Ada")),
+            &test_passkey(),
+        )
+        .await
+        .unwrap();
+
+        let renamed = rename_passkey(&pool, created.id, account.id, &name("MacBook"))
+            .await
+            .unwrap()
+            .expect("own passkey");
+        assert_eq!(renamed.id, created.id);
+        assert_eq!(renamed.name, "MacBook");
+
+        let other_account = rename_passkey(&pool, created.id, Uuid::new_v4(), &name("Nope"))
+            .await
+            .unwrap();
+        assert!(other_account.is_none());
+        let stored = PasskeyRepository::new(pool)
+            .list_for_account(account.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            stored[0].name, "MacBook",
+            "someone else's rename changed nothing"
+        );
+    }
+
+    #[sqlx::test]
+    async fn delete_removes_an_owned_passkey_only(pool: PgPool) {
+        let (account, created) = create_committed(
+            &pool,
+            NewAccount::full(display_name("Ada")),
+            &test_passkey(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !delete_passkey(&pool, created.id, Uuid::new_v4())
+                .await
+                .unwrap()
+        );
+        assert!(delete_passkey(&pool, created.id, account.id).await.unwrap());
+        assert!(!delete_passkey(&pool, created.id, account.id).await.unwrap());
+        assert!(
+            PasskeyRepository::new(pool)
+                .list_for_account(account.id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[sqlx::test]
+    async fn lock_lists_the_account_passkeys_in_id_order(pool: PgPool) {
+        let (account, first) = create_committed(
+            &pool,
+            NewAccount::full(display_name("Ada")),
+            &test_passkey(),
+        )
+        .await
+        .unwrap();
+        let second = insert_passkey(&pool, account.id, &test_passkey(), "Second")
+            .await
+            .unwrap();
+        let mut expected = vec![first.id, second.id];
+        expected.sort();
+
+        let mut tx = pool.begin().await.unwrap();
+        let locked = lock_passkeys(&mut *tx, account.id).await.unwrap();
+
+        assert_eq!(locked, expected);
+        assert!(
+            lock_passkeys(&mut *tx, Uuid::new_v4())
+                .await
+                .unwrap()
+                .is_empty()
         );
     }
 


### PR DESCRIPTION
Closes #668.

## Endpoints

All under `/api/passkeys`, all behind `Authenticated`; the account id comes from the session, never from the request.

| Request | Answer |
|---|---|
| `GET /api/passkeys` | `{"passkeys":[{id, name, createdAt, lastUsedAt}]}`, oldest first; the credential itself never leaves |
| `PATCH /api/passkeys/{id}` `{"name"}` | 200 with the renamed passkey; `400 invalid_passkey_name` for a bad name |
| `DELETE /api/passkeys/{id}` | 204; `409 last_passkey` for the account's only passkey |
| either with an id that is not yours or does not exist | `404 passkey_not_found`, the same answer for both |
| either with an id that is not a uuid | `400 invalid_path` in the `ApiError` shape |

## Decisions (ADR 0006)

- **Last passkey stays.** No recovery in v1, so a second passkey is the safety net. The delete counts under `SELECT ... FOR UPDATE` on the account's passkey rows: two concurrent deletes of the two remaining passkeys leave one (regression test with the row lock held while both requests start).
- **Not yours means not found.** Rename and delete filter by id and account id in one query.
- **A passkey's name is a display name.** `PasskeyName` reuses the `DisplayName` sanitising and validation (spaces, NFC, invisible characters, length) as one implementation; its own type because it is a different thing.
- **Deleting a passkey ends no session** (ADR 0004): the dashboard session carries on, and so does one opened on a lost device until it expires. "Sign out everywhere" comes with session listing.

## Gap worth a ticket

The API can remove a passkey but not **add** one to an existing account: there is no ceremony for a signed-in account to register another authenticator. Until it exists every account sits at its one registration passkey, and the dashboard (#671) needs it for the "add a second passkey" nudge. The `insert_passkey` write is already there for it.

## Tests

Service: list order, rename own only, delete own only, last passkey refused, someone else's refused, concurrent deletes leave one. Router: 401 on every endpoint, list shape, rename with sanitising, invalid name, 404 for other's and unknown ids on both rename and delete, delete keeps the session, 409 on the last one, malformed id. Composition: `/api/passkeys` mounted behind the `/api` layers.

`cargo test`: 190 passed. `cargo clippy --all-targets -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)